### PR TITLE
fix: do not crash on unresolved domain

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/mocha": "^5.2.5",
     "@types/nock": "^9.3.1",
     "@types/node": "^11.9.3",
+    "@types/sinon": "^7.0.5",
     "@types/update-notifier": "^2.5.0",
     "codecov": "^3.1.0",
     "gts": "^0.9.0",
@@ -44,6 +45,7 @@
     "nock": "^10.0.6",
     "nyc": "^13.2.0",
     "semantic-release": "^15.13.3",
+    "sinon": "^7.2.3",
     "source-map-support": "^0.5.10",
     "typescript": "^3.3.3"
   },

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,7 +1,8 @@
 import * as assert from 'assert';
+import * as gaxios from 'gaxios';
 import * as nock from 'nock';
 import * as sinon from 'sinon';
-import * as gaxios from 'gaxios';
+
 import {check, LinkState} from '../src';
 
 nock.disableNetConnect();
@@ -56,7 +57,7 @@ describe('linkinator', () => {
     const results = await check({path: 'test/fixtures/basic'});
     assert.ok(!results.passed);
     assert.strictEqual(
-      results.links.filter(x => x.state === LinkState.BROKEN).length, 1);
+        results.links.filter(x => x.state === LinkState.BROKEN).length, 1);
     requestStub.restore();
   });
 });

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,5 +1,7 @@
 import * as assert from 'assert';
 import * as nock from 'nock';
+import * as sinon from 'sinon';
+import * as gaxios from 'gaxios';
 import {check, LinkState} from '../src';
 
 nock.disableNetConnect();
@@ -46,5 +48,15 @@ describe('linkinator', () => {
     const results = await check({path: 'test/fixtures/relative'});
     assert.ok(results.passed);
     assert.strictEqual(results.links.length, 2);
+  });
+
+  it('should handle fetch exceptions', async () => {
+    const requestStub = sinon.stub(gaxios, 'request');
+    requestStub.throws('Fetch error');
+    const results = await check({path: 'test/fixtures/basic'});
+    assert.ok(!results.passed);
+    assert.strictEqual(
+      results.links.filter(x => x.state === LinkState.BROKEN).length, 1);
+    requestStub.restore();
   });
 });

--- a/test/test.ts
+++ b/test/test.ts
@@ -60,7 +60,7 @@ describe('linkinator', () => {
         results.links.filter(x => x.state === LinkState.BROKEN).length, 1);
     requestStub.restore();
   });
-    
+
   it('should skip mailto: links', async () => {
     const results = await check({path: 'test/fixtures/mailto'});
     assert.ok(results.passed);


### PR DESCRIPTION
If a website contains a link to non-resolvable domain, it gets an exception from `fetch` and crashes.
Easy repro: `npx linkinator http://nonexistentdomain123zozozo.com`

Fixing that.