### PR TITLE
fix: skip mailto links

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ export class LinkChecker extends EventEmitter {
    */
   async check(options: CheckOptions) {
     options.linksToSkip = options.linksToSkip || [];
+    options.linksToSkip.push('^mailto:');
     let server: http.Server|undefined;
     if (!options.path.startsWith('http')) {
       const port = options.port || 5000 + Math.round(Math.random() * 1000);

--- a/test/fixtures/mailto/index.html
+++ b/test/fixtures/mailto/index.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<a href="mailto:email@example.com">send me an email</a>
+</body>
+</html>

--- a/test/test.ts
+++ b/test/test.ts
@@ -47,4 +47,11 @@ describe('linkinator', () => {
     assert.ok(results.passed);
     assert.strictEqual(results.links.length, 2);
   });
+
+  it('should skip mailto: links', async () => {
+    const results = await check({path: 'test/fixtures/mailto'});
+    assert.ok(results.passed);
+    assert.strictEqual(
+        results.links.filter(x => x.state === LinkState.SKIPPED).length, 1);
+  });
 });


### PR DESCRIPTION
Always skip `mailto:` links since they are not real links.