### PR TITLE
 feat: add srcset attribute support

### DIFF
--- a/src/links.ts
+++ b/src/links.ts
@@ -16,6 +16,7 @@ const linksAttr = {
     'audio', 'embed', 'frame', 'iframe', 'img', 'input', 'script', 'source',
     'track', 'video'
   ],
+  srcset: ['img', 'source'],
 } as {[index: string]: string[]};
 
 export function getLinks(source: string, baseUrl: string) {
@@ -24,12 +25,23 @@ export function getLinks(source: string, baseUrl: string) {
   Object.keys(linksAttr).forEach(attr => {
     const elements = linksAttr[attr].map(tag => `${tag}[${attr}]`).join(',');
     $(elements).each((i, element) => {
-      links.push(element.attribs[attr]);
+      const values = parseAttr(attr, element.attribs[attr]);
+      links.push(...values);
     });
   });
   const sanitized =
       links.filter(link => !!link).map(link => normalizeLink(link, baseUrl));
   return sanitized;
+}
+
+function parseAttr(name: string, value: string): string[] {
+  switch (name) {
+    case 'srcset':
+      return value.split(',').map(
+          (pair: string) => pair.trim().split(/\s+/)[0]);
+    default:
+      return [value];
+  }
 }
 
 function normalizeLink(link: string, baseUrl: string): string {

--- a/test/fixtures/image/index.html
+++ b/test/fixtures/image/index.html
@@ -1,6 +1,6 @@
 <html>
 <body>
 <img src="missing.png">
-<img src="boo.jpg">
+<img src="boo.jpg" srcset="missing.jpg 2x">
 </body>
 </html>

--- a/test/test.ts
+++ b/test/test.ts
@@ -79,7 +79,7 @@ describe('linkinator', () => {
   it('should detect broken image links', async () => {
     const results = await check({path: 'test/fixtures/image'});
     assert.strictEqual(
-        results.links.filter(x => x.state === LinkState.BROKEN).length, 1);
+        results.links.filter(x => x.state === LinkState.BROKEN).length, 2);
     assert.strictEqual(
         results.links.filter(x => x.state === LinkState.OK).length, 2);
   });


### PR DESCRIPTION
Added support for [srcset image attribute](https://developer.mozilla.org/docs/Web/HTML/Element/img#attr-srcset).
Parsing done like in [sindresorhus/srcset](https://github.com/sindresorhus/srcset/blob/master/index.js#L12).