### PR TITLE
build: enforce consistent git line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Enforce Unix newlines
+* text=auto eol=lf


### PR DESCRIPTION
Without this, on Windows with `autocrlf: true` the files have CRLF.