### PR TITLE
Add support for directory indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Asynchronous method that runs a site wide scan. Options come in the form of an o
 - `path` (string) - A fully qualified path to the url to be scanned, or the path to the directory on disk that contains files to be scanned. *required*.
 - `port` (number) - When the `path` is provided as a local path on disk, the `port` on which to start the temporary web server.  Defaults to a random high range order port.
 - `recurse` (boolean) - By default, all scans are shallow.  Only the top level links on the requested page will be scanned.  By setting `recurse` to `true`, the crawler will follow all links on the page, and continue scanning links **on the same domain** for as long as it can go. Results are cached, so no worries about loops.
+- `directoryIndexes` (boolean) - If your site uses directory indexes, this setting avoids false-positives on relative links that would be correctly resolved by a server, but fail a `GET`/`HEAD` request.
 - `linksToSkip` (array) - An array of regular expression strings that should be skipped during the scan.
 
 #### linkinator.LinkChecker()

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export interface CheckOptions {
   port?: number;
   path: string;
   recurse?: boolean;
+  directoryIndexes?: boolean;
   linksToSkip?: string[];
 }
 
@@ -100,6 +101,11 @@ export class LinkChecker extends EventEmitter {
    * @returns A list of crawl results consisting of urls and status codes
    */
   private async crawl(opts: CrawlOptions): Promise<LinkResult[]> {
+    // Support directory indexes by adding a trailing slash if required
+    if (opts.checkOptions.directoryIndexes && !opts.url.match(/\/$|\./)) {
+      opts.url += '/';
+    }
+
     // Check to see if we've already scanned this url
     if (opts.cache.has(opts.url)) {
       return opts.results;

--- a/test/fixtures/relative/index.html
+++ b/test/fixtures/relative/index.html
@@ -2,5 +2,7 @@
 <body>
 <a href="ohai.html">go right over there</a>
 <a href="nested/index.html">go right over there</a>
+<a href="nested">go right over there</a>
+<a href="nested/">go right over there</a>
 </body>
 </html>

--- a/test/test.ts
+++ b/test/test.ts
@@ -61,9 +61,10 @@ describe('linkinator', () => {
     const results = await check({
       path: 'test/fixtures/relative',
       recurse: true,
+      directoryIndexes: true,
     });
     assert.ok(results.passed);
-    assert.strictEqual(results.links.length, 4);
+    assert.strictEqual(results.links.length, 5);
   });
 
   it('should handle fetch exceptions', async () => {


### PR DESCRIPTION
Adds a new `directoryIndexes` option to support resolving relative links in combination with directory indexes.

Refs: https://github.com/JustinBeckwith/linkinator/issues/34#issuecomment-499075791