### PR TITLE
Prep work for parallel requests. Added prettier options to package co…

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,13 @@
   "bin": {
     "linkinator": "build/src/cli.js"
   },
+  "prettier": {
+    "useTabs": false,
+    "singleQuote": true,
+    "tabWidth": 2,
+    "semi": true,
+    "printWidth": 160
+  },
   "scripts": {
     "pretest": "npm run compile",
     "prepare": "npm run compile",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ import { getLinks } from './links';
 const finalhandler = require('finalhandler');
 const serveStatic = require('serve-static');
 
+declare type url = string;
+
 export interface CheckOptions {
   port?: number;
   path: string;
@@ -18,11 +20,11 @@ export interface CheckOptions {
 export enum LinkState {
   OK = 'OK',
   BROKEN = 'BROKEN',
-  SKIPPED = 'SKIPPED',
+  SKIPPED = 'SKIPPED'
 }
 
 export interface LinkResult {
-  url: string;
+  url: url;
   status?: number;
   state: LinkState;
 }
@@ -33,42 +35,39 @@ export interface CrawlResult {
 }
 
 interface CrawlOptions {
-  url: string;
+  url: url;
   crawl: boolean;
   results: LinkResult[];
   cache: Set<string>;
   checkOptions: CheckOptions;
 }
 
-/**
- * Instance class used to perform a crawl job.
- */
+const isHtml = (response: gaxios.GaxiosResponse) => {
+  const contentType = response.headers['content-type'] || '';
+  return !!contentType.match('text/html');
+};
+
 export class LinkChecker extends EventEmitter {
-  /**
-   * Crawl a given url or path, and return a list of visited links along with
-   * status codes.
-   * @param options Options to use while checking for 404s
-   */
   async check(options: CheckOptions) {
     options.linksToSkip = options.linksToSkip || [];
     options.linksToSkip.push('^mailto:');
     let server: http.Server | undefined;
     if (!options.path.startsWith('http')) {
       const port = options.port || 5000 + Math.round(Math.random() * 1000);
-      server = await this.startWebServer(options.path, port);
+      server = await this._startStaticWebServer(options.path, port);
       enableDestroy(server);
       options.path = `http://localhost:${port}`;
     }
-    const results = await this.crawl({
+    const results = await this._filterCachedFilterSkippedThenCrawlUrlAndChildren({
       url: options.path,
       crawl: true,
       checkOptions: options,
       results: [],
-      cache: new Set(),
+      cache: new Set()
     });
     const result = {
       links: results,
-      passed: results.filter(x => x.state === LinkState.BROKEN).length === 0,
+      passed: results.filter(x => x.state === LinkState.BROKEN).length === 0
     };
     if (server) {
       server.destroy();
@@ -76,14 +75,7 @@ export class LinkChecker extends EventEmitter {
     return result;
   }
 
-  /**
-   * Spin up a local HTTP server to serve static requests from disk
-   * @param root The local path that should be mounted as a static web server
-   * @param port The port on which to start the local web server
-   * @private
-   * @returns Promise that resolves with the instance of the HTTP server
-   */
-  private startWebServer(root: string, port: number): Promise<http.Server> {
+  private _startStaticWebServer(root: string, port: number): Promise<http.Server> {
     return new Promise((resolve, reject) => {
       const serve = serveStatic(root);
       const server = http
@@ -93,13 +85,49 @@ export class LinkChecker extends EventEmitter {
     });
   }
 
-  /**
-   * Crawl a given url with the provided options.
-   * @pram opts List of options used to do the crawl
-   * @private
-   * @returns A list of crawl results consisting of urls and status codes
-   */
-  private async crawl(opts: CrawlOptions): Promise<LinkResult[]> {
+  private async _fetch(url: url, shouldCrawl: boolean) {
+    // Perform a HEAD or GET request based on the need to crawl
+    let status = 0;
+    let state = LinkState.BROKEN;
+    let data = '';
+    let shouldRecurse = false;
+    try {
+      let res = await gaxios.request<string>({
+        method: shouldCrawl ? 'GET' : 'HEAD',
+        url: url,
+        responseType: shouldCrawl ? 'text' : 'stream',
+        validateStatus: () => true
+      });
+
+      // If we got an HTTP 405, the server may not like HEAD. GET instead!
+      if (res.status === 405) {
+        res = await gaxios.request<string>({
+          method: 'GET',
+          url: url,
+          responseType: 'stream',
+          validateStatus: () => true
+        });
+      }
+
+      // Assume any 2xx status is 👌
+      status = res.status;
+      if (res.status >= 200 && res.status < 300) {
+        state = LinkState.OK;
+      }
+      data = res.data;
+      shouldRecurse = isHtml(res);
+    } catch (err) {
+      // request failure: invalid domain name, etc.
+    }
+    return {
+      data,
+      shouldRecurse,
+      linkResult: <LinkResult>{ url: url, status, state }
+    };
+  }
+
+  // todo: refactor to support parallel requests
+  private async _filterCachedFilterSkippedThenCrawlUrlAndChildren(opts: CrawlOptions): Promise<LinkResult[]> {
     // Check to see if we've already scanned this url
     if (opts.cache.has(opts.url)) {
       return opts.results;
@@ -119,57 +147,23 @@ export class LinkChecker extends EventEmitter {
       return opts.results;
     }
 
-    // Perform a HEAD or GET request based on the need to crawl
-    let status = 0;
-    let state = LinkState.BROKEN;
-    let data = '';
-    let shouldRecurse = false;
-    try {
-      let res = await gaxios.request<string>({
-        method: opts.crawl ? 'GET' : 'HEAD',
-        url: opts.url,
-        responseType: opts.crawl ? 'text' : 'stream',
-        validateStatus: () => true,
-      });
-
-      // If we got an HTTP 405, the server may not like HEAD. GET instead!
-      if (res.status === 405) {
-        res = await gaxios.request<string>({
-          method: 'GET',
-          url: opts.url,
-          responseType: 'stream',
-          validateStatus: () => true,
-        });
-      }
-
-      // Assume any 2xx status is 👌
-      status = res.status;
-      if (res.status >= 200 && res.status < 300) {
-        state = LinkState.OK;
-      }
-      data = res.data;
-      shouldRecurse = isHtml(res);
-    } catch (err) {
-      // request failure: invalid domain name, etc.
-    }
-    const result: LinkResult = { url: opts.url, status, state };
-    opts.results.push(result);
-    this.emit('link', result);
+    const fetchResult = await this._fetch(opts.url, opts.crawl);
+    opts.results.push(fetchResult.linkResult);
+    this.emit('link', fetchResult);
 
     // If we need to go deeper, scan the next level of depth for links and crawl
-    if (opts.crawl && shouldRecurse) {
+    if (opts.crawl && fetchResult.shouldRecurse) {
       this.emit('pagestart', opts.url);
-      const urls = getLinks(data, opts.url);
+      const urls = getLinks(fetchResult.data, opts.url);
       for (const url of urls) {
         // only crawl links that start with the same host
-        const crawl =
-          opts.checkOptions.recurse! && url.startsWith(opts.checkOptions.path);
-        await this.crawl({
+        const crawl = opts.checkOptions.recurse! && url.startsWith(opts.checkOptions.path);
+        await this._filterCachedFilterSkippedThenCrawlUrlAndChildren({
           url,
           crawl,
           cache: opts.cache,
           results: opts.results,
-          checkOptions: opts.checkOptions,
+          checkOptions: opts.checkOptions
         });
       }
     }
@@ -179,22 +173,8 @@ export class LinkChecker extends EventEmitter {
   }
 }
 
-/**
- * Convenience method to perform a scan.
- * @param options CheckOptions to be passed on
- */
 export async function check(options: CheckOptions) {
   const checker = new LinkChecker();
   const results = await checker.check(options);
   return results;
-}
-
-/**
- * Checks to see if a given source is HTML.
- * @param {object} response Page response.
- * @returns {boolean}
- */
-function isHtml(response: gaxios.GaxiosResponse): boolean {
-  const contentType = response.headers['content-type'] || '';
-  return !!contentType.match('text/html');
 }


### PR DESCRIPTION
…nfig. Removed doc comments. Split crawl method into 2.

I renamed the big "crawl" method to reflect what it was doing as step 1. Next the plan is to split up the filtering into separate methods. Then will be easier to parallelize it.