### PR TITLE
feat: enable concurrent requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ $ linkinator LOCATION [ --arguments ]
     --config
         Path to the config file to use. Looks for `linkinator.config.json` by default.
 
+    --concurrency
+          The number of connections to make simultaneously. Defaults to 100.
+
     --recurse, -r
         Recurively follow links on the same root domain.
 
@@ -105,6 +108,7 @@ All options are optional. It should look like this:
   "format": "json",
   "recurse": true,
   "silent": true,
+  "concurrency": 100,
   "skip": "www.googleapis.com"
 }
 ```
@@ -120,6 +124,7 @@ $ linkinator --config /some/path/your-config.json
 #### linkinator.check(options)
 Asynchronous method that runs a site wide scan. Options come in the form of an object that includes:
 - `path` (string) - A fully qualified path to the url to be scanned, or the path to the directory on disk that contains files to be scanned. *required*.
+- `concurrency` (number) -  The number of connections to make simultaneously. Defaults to 100.
 - `port` (number) - When the `path` is provided as a local path on disk, the `port` on which to start the temporary web server.  Defaults to a random high range order port.
 - `recurse` (boolean) - By default, all scans are shallow.  Only the top level links on the requested page will be scanned.  By setting `recurse` to `true`, the crawler will follow all links on the page, and continue scanning links **on the same domain** for as long as it can go. Results are cached, so no worries about loops.
 - `linksToSkip` (array) - An array of regular expression strings that should be skipped during the scan.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gaxios": "^2.0.1",
     "jsonexport": "^2.4.1",
     "meow": "^5.0.0",
+    "p-queue": "^6.2.1",
     "serve-static": "^1.14.1",
     "server-destroy": "^1.0.1",
     "update-notifier": "^3.0.1"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -73,36 +73,36 @@ async function main() {
 
   const start = Date.now();
 
-  // if (!flags.silent) {
-  //   log(`🏊‍♂️ crawling ${cli.input}`);
-  // }
+  if (!flags.silent) {
+    log(`🏊‍♂️ crawling ${cli.input}`);
+  }
   const checker = new LinkChecker();
   // checker.on('pagestart', url => {
   //   if (!flags.silent) {
   //     log(`\n Scanning ${chalk.grey(url)}`);
   //   }
   // });
-  // checker.on('link', (link: LinkResult) => {
-  //   if (flags.silent && link.state !== LinkState.BROKEN) {
-  //     return;
-  //   }
+  checker.on('link', (link: LinkResult) => {
+    if (flags.silent && link.state !== LinkState.BROKEN) {
+      return;
+    }
 
-  //   let state = '';
-  //   switch (link.state) {
-  //     case LinkState.BROKEN:
-  //       state = `[${chalk.red(link.status!.toString())}]`;
-  //       break;
-  //     case LinkState.OK:
-  //       state = `[${chalk.green(link.status!.toString())}]`;
-  //       break;
-  //     case LinkState.SKIPPED:
-  //       state = `[${chalk.grey('SKP')}]`;
-  //       break;
-  //     default:
-  //       throw new Error('Invalid state.');
-  //   }
-  //   log(`  ${state} ${chalk.gray(link.url)}`);
-  // });
+    let state = '';
+    switch (link.state) {
+      case LinkState.BROKEN:
+        state = `[${chalk.red(link.status!.toString())}]`;
+        break;
+      case LinkState.OK:
+        state = `[${chalk.green(link.status!.toString())}]`;
+        break;
+      case LinkState.SKIPPED:
+        state = `[${chalk.grey('SKP')}]`;
+        break;
+      default:
+        throw new Error('Invalid state.');
+    }
+    log(`${state} ${chalk.gray(link.url)}`);
+  });
   const opts: CheckOptions = {
     path: cli.input[0],
     recurse: flags.recurse,
@@ -134,7 +134,7 @@ async function main() {
       }
       acc[parent].push(curr);
       return acc;
-    }, {} as { [index: string]: LinkResult[]});
+    }, {} as { [index: string]: LinkResult[] });
     Object.keys(parents).forEach(parent => {
       const links = parents[parent];
       log(chalk.blue(parent));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,9 @@ const cli = meow(
       --config
           Path to the config file to use. Looks for \`linkinator.config.json\` by default.
 
+      --concurrency
+          The number of connections to make simultaneously. Defaults to 100.
+
       --recurse, -r
           Recurively follow links on the same root domain.
 
@@ -50,6 +53,7 @@ const cli = meow(
   {
     flags: {
       config: { type: 'string' },
+      concurrency: { type: 'string' },
       recurse: { type: 'boolean', alias: 'r', default: undefined },
       skip: { type: 'string', alias: 's' },
       format: { type: 'string', alias: 'f' },
@@ -99,7 +103,11 @@ async function main() {
     }
     log(`  ${state} ${chalk.gray(link.url)}`);
   });
-  const opts: CheckOptions = { path: cli.input[0], recurse: flags.recurse };
+  const opts: CheckOptions = {
+    path: cli.input[0],
+    recurse: flags.recurse,
+    concurrency: flags.concurrency
+  };
   if (flags.skip) {
     if (typeof flags.skip === 'string') {
       opts.linksToSkip = flags.skip.split(' ').filter(x => !!x);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -106,7 +106,7 @@ async function main() {
   const opts: CheckOptions = {
     path: cli.input[0],
     recurse: flags.recurse,
-    concurrency: flags.concurrency
+    concurrency: flags.concurrency,
   };
   if (flags.skip) {
     if (typeof flags.skip === 'string') {

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ import { promisify } from 'util';
 const readFile = promisify(fs.readFile);
 
 export interface Flags {
+  concurrency?: number;
   config?: string;
   recurse?: boolean;
   skip?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,7 +135,7 @@ export class LinkChecker extends EventEmitter {
       const result: LinkResult = {
         url: opts.url,
         state: LinkState.SKIPPED,
-        parent: opts.parent
+        parent: opts.parent,
       };
       opts.results.push(result);
       this.emit('link', result);
@@ -179,7 +179,7 @@ export class LinkChecker extends EventEmitter {
       url: opts.url,
       status,
       state,
-      parent: opts.parent
+      parent: opts.parent,
     };
     opts.results.push(result);
     this.emit('link', result);
@@ -208,7 +208,7 @@ export class LinkChecker extends EventEmitter {
             results: opts.results,
             checkOptions: opts.checkOptions,
             queue: opts.queue,
-            parent: opts.url
+            parent: opts.url,
           });
         });
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events';
 import * as gaxios from 'gaxios';
 import * as http from 'http';
 import enableDestroy = require('server-destroy');
+import PQueue from 'p-queue';
 
 import { getLinks } from './links';
 import { URL } from 'url';
@@ -10,6 +11,7 @@ const finalhandler = require('finalhandler');
 const serveStatic = require('serve-static');
 
 export interface CheckOptions {
+  concurrency?: number;
   port?: number;
   path: string;
   recurse?: boolean;
@@ -60,6 +62,11 @@ export class LinkChecker extends EventEmitter {
       enableDestroy(server);
       options.path = `http://localhost:${port}`;
     }
+
+    const queue = new PQueue({
+      concurrency: 10
+    });
+
     const results = await this.crawl({
       url: options.path,
       crawl: true,

--- a/test/fixtures/config/linkinator.config.json
+++ b/test/fixtures/config/linkinator.config.json
@@ -2,5 +2,6 @@
   "format": "json",
   "recurse": true,
   "silent": true,
+  "concurrency": 17,
   "skip": "🌳"
 }

--- a/test/test.config.ts
+++ b/test/test.config.ts
@@ -10,6 +10,7 @@ describe('config', () => {
       recurse: true,
       silent: true,
       skip: '🌳',
+      concurrency: 22
     };
     const config = await getConfig(cfg);
     assert.deepStrictEqual(config, cfg);

--- a/test/test.config.ts
+++ b/test/test.config.ts
@@ -10,7 +10,7 @@ describe('config', () => {
       recurse: true,
       silent: true,
       skip: '🌳',
-      concurrency: 22
+      concurrency: 22,
     };
     const config = await getConfig(cfg);
     assert.deepStrictEqual(config, cfg);


### PR DESCRIPTION
Fixes #35.  This adds a `--concurrency` flag and config option that parallelizes requests.   