### PR TITLE
feat: add missing --include flag & linksToInclude option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Behold my latest inator! The `linkinator` provides an API and CLI for crawling w
 - 🔥Easily perform scans on remote sites or local files
 - 🔥Scan any element that includes links, not just `<a href>`
 - 🔥Supports redirects, absolute links, relative links, all the things
-- 🔥Configure specific regex patterns to skip
+- 🔥Configure specific regex patterns to skip and ignore it when needed
 
 ## Installation
 
@@ -128,6 +128,7 @@ Asynchronous method that runs a site wide scan. Options come in the form of an o
 - `port` (number) - When the `path` is provided as a local path on disk, the `port` on which to start the temporary web server.  Defaults to a random high range order port.
 - `recurse` (boolean) - By default, all scans are shallow.  Only the top level links on the requested page will be scanned.  By setting `recurse` to `true`, the crawler will follow all links on the page, and continue scanning links **on the same domain** for as long as it can go. Results are cached, so no worries about loops.
 - `linksToSkip` (array) - An array of regular expression strings that should be skipped during the scan.
+- `linksToInclude` (array) - An array of regular expression strings that should be included even if it should be skipped by rules during the scan.
 
 #### linkinator.LinkChecker()
 Constructor method that can be used to create a new `LinkChecker` instance.  This is particularly useful if you want to receive events as the crawler crawls.  Exposes the following events:
@@ -210,6 +211,9 @@ async function complex() {
     // linksToSkip: [
     //   'https://jbeckwith.com/some/link',
     //   'http://example.com'
+    // ]
+    // linksToInclude: [
+    //   /important/i
     // ]
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,6 +34,9 @@ const cli = meow(
       --skip, -s
           List of urls in regexy form to not include in the check.
 
+      --include, -i
+          List of urls in regexy form to force include in the check.
+
       --format, -f
           Return the data in CSV or JSON format.
 
@@ -48,6 +51,7 @@ const cli = meow(
       $ linkinator https://www.google.com
       $ linkinator . --recurse
       $ linkinator . --skip www.googleapis.com
+      $ linkinator . --skip www.googleapis.com --include /api/v2
       $ linkinator . --format CSV
 `,
   {
@@ -56,6 +60,7 @@ const cli = meow(
       concurrency: { type: 'string' },
       recurse: { type: 'boolean', alias: 'r', default: undefined },
       skip: { type: 'string', alias: 's' },
+      include: { type: 'string', alias: 'i' },
       format: { type: 'string', alias: 'f' },
       silent: { type: 'boolean', default: undefined },
     },
@@ -113,6 +118,13 @@ async function main() {
       opts.linksToSkip = flags.skip.split(' ').filter(x => !!x);
     } else if (Array.isArray(flags.skip)) {
       opts.linksToSkip = flags.skip;
+    }
+  }
+  if (flags.include) {
+    if (typeof flags.include === 'string') {
+      opts.linksToInclude = flags.include.split(' ').filter(x => !!x);
+    } else if (Array.isArray(flags.include)) {
+      opts.linksToInclude = flags.include;
     }
   }
   const result = await checker.check(opts);

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ export interface Flags {
   config?: string;
   recurse?: boolean;
   skip?: string;
+  include?: string;
   format?: string;
   silent?: boolean;
 }

--- a/test/fixtures/config/linkinator.config.json
+++ b/test/fixtures/config/linkinator.config.json
@@ -3,5 +3,6 @@
   "recurse": true,
   "silent": true,
   "concurrency": 17,
-  "skip": "🌳"
+  "skip": "🌳",
+  "include": "🚀"
 }

--- a/test/fixtures/include/index.html
+++ b/test/fixtures/include/index.html
@@ -1,0 +1,10 @@
+<html>
+<body>
+<a href="http://fake.local/INCLUDED_part/end">we should include dis one</a>
+<a href="http://fake.local/included_part">we should include dis one</a>
+<a href="http://fake.local/very_bad">we should skip dis one</a>
+<a href="http://fake.local/force_included_part_very_bad/for_example">we should include dis one forcely</a>
+<a href="http://fake.local/very_bad/force_included_PART">we should include dis one forcely</a>
+<a href="http://fake.local/something/else/very_bad">we should skip dis one</a>
+</body>
+</html>

--- a/test/test.ts
+++ b/test/test.ts
@@ -45,6 +45,30 @@ describe('linkinator', () => {
     );
   });
 
+  it('should include even skipped links if asked forcely', async () => {
+    const scope = nock('http://fake.local')
+      .head('/INCLUDED_part/end')
+      .reply(200)
+      .head('/included_part')
+      .reply(200)
+      .head('/force_included_part_very_bad/for_example')
+      .reply(200)
+      .head('/very_bad/force_included_PART')
+      .reply(200);
+    const results = await check({
+      path: 'test/fixtures/include',
+      linksToSkip: [/very_bad/],
+      linksToInclude: [/included_part/i],
+    });
+    assert.ok(results.passed);
+    assert.strictEqual(results.links.length, 7);
+    assert.strictEqual(
+      results.links.filter(x => x.state === LinkState.SKIPPED).length,
+      2
+    );
+    scope.done();
+  });
+
   it('should report broken links', async () => {
     const scope = nock('http://fake.local')
       .head('/')


### PR DESCRIPTION
You have --include flag description in README but part with implementation is kinda missing. As I suppose it should work like same flag in other tooling. Or maybe even like .ignore files - with ! at start of strings.

We need something like that in our small project in which I implement your lib. So I hope it's ok, my accidentaly PRs.

Here the issue https://github.com/JustinBeckwith/linkinator/issues/44