### PR TITLE
Relative urls and redirects issue 

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "chalk": "^3.0.0",
     "cheerio": "^1.0.0-rc.2",
     "finalhandler": "^1.1.2",
-    "gaxios": "^2.0.1",
+    "gaxios": "^2.2.0",
     "jsonexport": "^2.4.1",
     "meow": "^5.0.0",
     "p-queue": "^6.2.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -175,6 +175,8 @@ export class LinkChecker extends EventEmitter {
     // Perform a HEAD or GET request based on the need to crawl
     let status = 0;
     let state = LinkState.BROKEN;
+    let responseUrl = opts.url.href;
+
     let data = '';
     let shouldRecurse = false;
     try {
@@ -195,6 +197,7 @@ export class LinkChecker extends EventEmitter {
         });
       }
 
+      responseUrl = res.request.responseURL;
       // Assume any 2xx status is 👌
       status = res.status;
       if (res.status >= 200 && res.status < 300) {
@@ -206,7 +209,7 @@ export class LinkChecker extends EventEmitter {
       // request failure: invalid domain name, etc.
     }
     const result: LinkResult = {
-      url: opts.url.href,
+      url: responseUrl,
       status,
       state,
       parent: opts.parent,
@@ -217,7 +220,7 @@ export class LinkChecker extends EventEmitter {
     // If we need to go deeper, scan the next level of depth for links and crawl
     if (opts.crawl && shouldRecurse) {
       this.emit('pagestart', opts.url);
-      const urlResults = getLinks(data, opts.url.href);
+      const urlResults = getLinks(data, result.url);
       for (const result of urlResults) {
         // if there was some sort of problem parsing the link while
         // creating a new URL obj, treat it as a broken link.

--- a/src/links.ts
+++ b/src/links.ts
@@ -49,8 +49,9 @@ export function getLinks(source: string, baseUrl: string): ParsedUrl[] {
   if (base.length) {
     // only first <base by specification
     const htmlBaseUrl = base.first().attr('href');
-
-    realBaseUrl = getBaseUrl(htmlBaseUrl, baseUrl);
+    if (htmlBaseUrl) {
+      realBaseUrl = getBaseUrl(htmlBaseUrl, baseUrl);
+    }
   }
 
   const sanitized = links


### PR DESCRIPTION
Example test for issue #108 

- `/subfolder/index` redirects to `/index` 
- `/index` content are links `./ok` & `./broken`

Not the same result for checking urls with and without redirect.

Proposal: use real response url at `index.js:149`
Need also https://github.com/googleapis/gaxios/issues/187