### PR TITLE
feat: HTML base tag support

### DIFF
--- a/test/fixtures/basetag/absolute.html
+++ b/test/fixtures/basetag/absolute.html
@@ -1,0 +1,12 @@
+<html>
+  <head>
+    <base href="http://another.fake.local/" />
+    <base href="./unused" />
+  </head>
+  <body>
+    <a href="ok">relative link</a>
+    <a href="broken">relative link</a>
+    <a href="./ok">relative link</a>
+    <a href="./broken">relative link</a>
+  </body>
+</html>

--- a/test/fixtures/basetag/empty-base.html
+++ b/test/fixtures/basetag/empty-base.html
@@ -1,0 +1,11 @@
+<html>
+  <head>
+    <base href="" />
+  </head>
+  <body>
+    <a href="ok">relative link</a>
+    <a href="broken">relative link</a>
+    <a href="./ok">relative link</a>
+    <a href="./broken">relative link</a>
+  </body>
+</html>

--- a/test/fixtures/basetag/relative-dot-folder.html
+++ b/test/fixtures/basetag/relative-dot-folder.html
@@ -1,0 +1,11 @@
+<html>
+  <head>
+    <base href="./anotherBase/" />
+  </head>
+  <body>
+    <a href="ok">relative link</a>
+    <a href="broken">relative link</a>
+    <a href="./ok">relative link</a>
+    <a href="./broken">relative link</a>
+  </body>
+</html>

--- a/test/fixtures/basetag/relative-folder.html
+++ b/test/fixtures/basetag/relative-folder.html
@@ -1,0 +1,11 @@
+<html>
+  <head>
+    <base href="anotherBase/" />
+  </head>
+  <body>
+    <a href="ok">relative link</a>
+    <a href="broken">relative link</a>
+    <a href="./ok">relative link</a>
+    <a href="./broken">relative link</a>
+  </body>
+</html>

--- a/test/fixtures/basetag/relative-page.html
+++ b/test/fixtures/basetag/relative-page.html
@@ -1,0 +1,11 @@
+<html>
+  <head>
+    <base href="anotherBase" />
+  </head>
+  <body>
+    <a href="ok">relative link</a>
+    <a href="broken">relative link</a>
+    <a href="./ok">relative link</a>
+    <a href="./broken">relative link</a>
+  </body>
+</html>

--- a/test/fixtures/basetag/relative-to-root.html
+++ b/test/fixtures/basetag/relative-to-root.html
@@ -1,0 +1,11 @@
+<html>
+  <head>
+    <base href="/anotherBase/" />
+  </head>
+  <body>
+    <a href="ok">relative link</a>
+    <a href="broken">relative link</a>
+    <a href="./ok">relative link</a>
+    <a href="./broken">relative link</a>
+  </body>
+</html>


### PR DESCRIPTION
E-commerce sites uses base tag for static pages with nginx rewrites.

Supported cases: 
- [x] only first `<base>` tag with non-empty `href`
- [x] empty base href
- [x] absolute base `http://cdn.example.com/some`
- [x] relative `./new_base`
- [x] relative `new_base`
- [x] relative `new_base/`

Usage of is-absolute-url (unfortunately by copy-paste) & URL can guarantee spec-compliant behaviour.