### PR TITLE
feat: add `filter` function as an option to linkinator.check()

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Asynchronous method that runs a site wide scan. Options come in the form of an o
 - `port` (number) - When the `path` is provided as a local path on disk, the `port` on which to start the temporary web server.  Defaults to a random high range order port.
 - `recurse` (boolean) - By default, all scans are shallow.  Only the top level links on the requested page will be scanned.  By setting `recurse` to `true`, the crawler will follow all links on the page, and continue scanning links **on the same domain** for as long as it can go. Results are cached, so no worries about loops.
 - `linksToSkip` (array) - An array of regular expression strings that should be skipped during the scan.
-- `filterLinks` (function) - A function that's called for each link with the link URL as its only argument. Return `true` to skip the link or `false` to check it.
+- `filter` (function) - A function that's called for each link with the link URL as its only argument. Return `true` to check the link or `false` to skip it.
 
 #### linkinator.LinkChecker()
 Constructor method that can be used to create a new `LinkChecker` instance.  This is particularly useful if you want to receive events as the crawler crawls.  Exposes the following events:

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Asynchronous method that runs a site wide scan. Options come in the form of an o
 - `concurrency` (number) -  The number of connections to make simultaneously. Defaults to 100.
 - `port` (number) - When the `path` is provided as a local path on disk, the `port` on which to start the temporary web server.  Defaults to a random high range order port.
 - `recurse` (boolean) - By default, all scans are shallow.  Only the top level links on the requested page will be scanned.  By setting `recurse` to `true`, the crawler will follow all links on the page, and continue scanning links **on the same domain** for as long as it can go. Results are cached, so no worries about loops.
-- `linksToSkip` (array | function) - An array of regular expression strings that should be skipped, OR a function that's called for each link with the link URL as its only argument. Return `true` to skip the link or `false` to check it.
+- `linksToSkip` (array | function) - An array of regular expression strings that should be skipped, OR an async function that's called for each link with the link URL as its only argument. Return a Promise that resolves to `true` to skip the link or `false` to check it.
 
 #### linkinator.LinkChecker()
 Constructor method that can be used to create a new `LinkChecker` instance.  This is particularly useful if you want to receive events as the crawler crawls.  Exposes the following events:

--- a/README.md
+++ b/README.md
@@ -127,8 +127,7 @@ Asynchronous method that runs a site wide scan. Options come in the form of an o
 - `concurrency` (number) -  The number of connections to make simultaneously. Defaults to 100.
 - `port` (number) - When the `path` is provided as a local path on disk, the `port` on which to start the temporary web server.  Defaults to a random high range order port.
 - `recurse` (boolean) - By default, all scans are shallow.  Only the top level links on the requested page will be scanned.  By setting `recurse` to `true`, the crawler will follow all links on the page, and continue scanning links **on the same domain** for as long as it can go. Results are cached, so no worries about loops.
-- `linksToSkip` (array) - An array of regular expression strings that should be skipped during the scan.
-- `filter` (function) - A function that's called for each link with the link URL as its only argument. Return `true` to check the link or `false` to skip it.
+- `linksToSkip` (array | function) - An array of regular expression strings that should be skipped, OR a function that's called for each link with the link URL as its only argument. Return `true` to skip the link or `false` to check it.
 
 #### linkinator.LinkChecker()
 Constructor method that can be used to create a new `LinkChecker` instance.  This is particularly useful if you want to receive events as the crawler crawls.  Exposes the following events:

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Asynchronous method that runs a site wide scan. Options come in the form of an o
 - `port` (number) - When the `path` is provided as a local path on disk, the `port` on which to start the temporary web server.  Defaults to a random high range order port.
 - `recurse` (boolean) - By default, all scans are shallow.  Only the top level links on the requested page will be scanned.  By setting `recurse` to `true`, the crawler will follow all links on the page, and continue scanning links **on the same domain** for as long as it can go. Results are cached, so no worries about loops.
 - `linksToSkip` (array) - An array of regular expression strings that should be skipped during the scan.
+- `filterLinks` (function) - A function that's called for each link with the link URL as its only argument. Return `true` to skip the link or `false` to check it.
 
 #### linkinator.LinkChecker()
 Constructor method that can be used to create a new `LinkChecker` instance.  This is particularly useful if you want to receive events as the crawler crawls.  Exposes the following events:

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export interface CheckOptions {
   path: string;
   recurse?: boolean;
   linksToSkip?: string[];
-  filterLink?: (arg0: string) => boolean;
+  filter?: (arg0: string) => boolean;
 }
 
 export enum LinkState {
@@ -147,8 +147,7 @@ export class LinkChecker extends EventEmitter {
 
     if (
       skips.length > 0 ||
-      (opts.checkOptions.filterLink &&
-        opts.checkOptions.filterLink(opts.url.href))
+      (opts.checkOptions.filter && !opts.checkOptions.filter(opts.url.href))
     ) {
       const result: LinkResult = {
         url: opts.url.href,

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export interface CheckOptions {
   path: string;
   recurse?: boolean;
   linksToSkip?: string[];
+  filterLink?: (arg0: string) => boolean;
 }
 
 export enum LinkState {
@@ -144,7 +145,7 @@ export class LinkChecker extends EventEmitter {
       })
       .filter(match => !!match);
 
-    if (skips.length > 0) {
+    if (skips.length > 0 || (opts.checkOptions.filterLink && opts.checkOptions.filterLink(opts.url.href))) {
       const result: LinkResult = {
         url: opts.url.href,
         state: LinkState.SKIPPED,

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ export interface CheckOptions {
   port?: number;
   path: string;
   recurse?: boolean;
-  linksToSkip?: string[] | ((link: string) => boolean);
+  linksToSkip?: string[] | ((link: string) => Promise<boolean>);
 }
 
 export enum LinkState {
@@ -140,7 +140,7 @@ export class LinkChecker extends EventEmitter {
     // Check for a user-configured function to filter out links
     if (
       typeof opts.checkOptions.linksToSkip === 'function' &&
-      opts.checkOptions.linksToSkip(opts.url.href)
+      (await opts.checkOptions.linksToSkip(opts.url.href))
     ) {
       const result: LinkResult = {
         url: opts.url.href,

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,7 +145,11 @@ export class LinkChecker extends EventEmitter {
       })
       .filter(match => !!match);
 
-    if (skips.length > 0 || (opts.checkOptions.filterLink && opts.checkOptions.filterLink(opts.url.href))) {
+    if (
+      skips.length > 0 ||
+      (opts.checkOptions.filterLink &&
+        opts.checkOptions.filterLink(opts.url.href))
+    ) {
       const result: LinkResult = {
         url: opts.url.href,
         state: LinkState.SKIPPED,

--- a/test/fixtures/filter/index.html
+++ b/test/fixtures/filter/index.html
@@ -1,0 +1,7 @@
+<html>
+<body>
+<a href="https://good.com">I'm good</a>
+<a href="http://www.filterme.com">I should be filtered</a>
+<a href="https://example.com/filtermetoo">I should also be filtered</a>
+</body>
+</html>

--- a/test/test.ts
+++ b/test/test.ts
@@ -51,9 +51,9 @@ describe('linkinator', () => {
       .reply(200);
     const results = await check({
       path: 'test/fixtures/filter',
-      filterLink: (href) => {
-        return href.includes('filterme')
-      }
+      filterLink: href => {
+        return href.includes('filterme');
+      },
     });
     assert.ok(results.passed);
     assert.strictEqual(

--- a/test/test.ts
+++ b/test/test.ts
@@ -51,8 +51,8 @@ describe('linkinator', () => {
       .reply(200);
     const results = await check({
       path: 'test/fixtures/filter',
-      filterLink: href => {
-        return href.includes('filterme');
+      filter: href => {
+        return !href.includes('filterme');
       },
     });
     assert.ok(results.passed);

--- a/test/test.ts
+++ b/test/test.ts
@@ -45,6 +45,24 @@ describe('linkinator', () => {
     );
   });
 
+  it('should skip links if passed a filterLink function', async () => {
+    const scope = nock('https://good.com')
+      .head('/')
+      .reply(200);
+    const results = await check({
+      path: 'test/fixtures/filter',
+      filterLink: (href) => {
+        return href.includes('filterme')
+      }
+    });
+    assert.ok(results.passed);
+    assert.strictEqual(
+      results.links.filter(x => x.state === LinkState.SKIPPED).length,
+      2
+    );
+    scope.done();
+  });
+
   it('should report broken links', async () => {
     const scope = nock('http://fake.local')
       .head('/')

--- a/test/test.ts
+++ b/test/test.ts
@@ -51,7 +51,7 @@ describe('linkinator', () => {
       .reply(200);
     const results = await check({
       path: 'test/fixtures/filter',
-      linksToSkip: link => link.includes('filterme'),
+      linksToSkip: link => Promise.resolve(link.includes('filterme')),
     });
     assert.ok(results.passed);
     assert.strictEqual(

--- a/test/test.ts
+++ b/test/test.ts
@@ -51,7 +51,7 @@ describe('linkinator', () => {
       .reply(200);
     const results = await check({
       path: 'test/fixtures/filter',
-      linksToSkip: link => link.includes('filterme')
+      linksToSkip: link => link.includes('filterme'),
     });
     assert.ok(results.passed);
     assert.strictEqual(

--- a/test/test.ts
+++ b/test/test.ts
@@ -45,15 +45,13 @@ describe('linkinator', () => {
     );
   });
 
-  it('should skip links if passed a filterLink function', async () => {
+  it('should skip links if passed a linksToSkip function', async () => {
     const scope = nock('https://good.com')
       .head('/')
       .reply(200);
     const results = await check({
       path: 'test/fixtures/filter',
-      filter: href => {
-        return !href.includes('filterme');
-      },
+      linksToSkip: link => link.includes('filterme')
     });
     assert.ok(results.passed);
     assert.strictEqual(


### PR DESCRIPTION
This PR adds a new `filterLinks` option to the `linkinator.check` function. The new option is a function that can be used to determine which URLs to skip and which to keep.

I'm not attached to the name of this option, nor the implementation. I'm open to alternatives ways of solving this that would expose the same level of flexibility to module users.