### PR TITLE
docs: include result.parent property in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,9 @@ async function complex() {
 
     // What was the status code of the response?
     console.log(`  ${result.status}`);
+
+    // What page linked here?
+    console.log(`  ${result.parent}`);
   });
 
   // Go ahead and start the scan! As events occur, we will see them above.


### PR DESCRIPTION
The objects provided to the `link` event handler look like this:

```js
{
  url: 'https://example.com/some-page',
  status: 404,
  state: 'OK',
  parent: 'https://example.com/the-page-that-linked-to-it'
}
```

This PR updates the example in the README to mention the `parent` property.