### PR TITLE
chore: replace deprecated mocha.opts with package.json config

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,5 +76,11 @@
     "exclude": [
       "build/test"
     ]
+  },
+  "mocha": {
+    "check-leaks": true,
+    "timeout": 10000,
+    "throw-deprecation": true,
+    "require": "source-map-support/register"
   }
 }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,0 @@
---check-leaks
---timeout 10000
---throw-deprecation
---require source-map-support/register


### PR DESCRIPTION
With current release of mocha, `npm test` prints a deprecation warning:

(node:10712) DeprecationWarning: Configuration via mocha.opts is
DEPRECATED and will be removed from a future version of Mocha. Use RC
files or package.json instead.

Move to package.json to eliminate the warning.