### PR TITLE
build!: drop support for node.js 8.x

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 container:
-  image: node:10
+  image: node:12
 
 windows_task:
   windows_container:
@@ -15,9 +15,9 @@ lint_task:
 test_task:
   container:
     matrix:
+      image: node:13
       image: node:12
       image: node:10
-      image: node:8
   install_script: npm install
   test_script: npm test
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "typescript": "^3.6.4"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "files": [
     "build/src"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "./node_modules/gts/tsconfig-google.json",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "build"
+    "outDir": "build",
+    "target": "es2018"
   },
   "include": [
     "src/*.ts",


### PR DESCRIPTION
BREAKING CHANGE: This module now requires Node.js 10.x or greater.
Please upgrade to a LTS release of node.js.