### PR TITLE
test: make sure links are queued just once

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -117,6 +117,7 @@ export class LinkChecker extends EventEmitter {
    * @returns A list of crawl results consisting of urls and status codes
    */
   private async crawl(opts: CrawlOptions): Promise<void> {
+    this.emit('crawl', opts.url.href);
     // Check to see if we've already scanned this url
     if (opts.cache.has(opts.url.href)) {
       return;


### PR DESCRIPTION
This shows the problem with `linkinator` and `#fragments`. The modified test is supposed to fail :)

One possible way of fixing this is to check/set `opt.cache` before adding a new element to the queue.

Cc: @xiaozhenliu-gg5 @JustinBeckwith 