### PR TITLE
fix: bug where it would fail urls that were valid

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -174,8 +174,9 @@ export class LinkChecker extends EventEmitter {
     let state = LinkState.BROKEN;
     let data = '';
     let shouldRecurse = false;
+    let res: gaxios.GaxiosResponse<string> | undefined = undefined;
     try {
-      let res = await gaxios.request<string>({
+      res = await gaxios.request<string>({
         method: opts.crawl ? 'GET' : 'HEAD',
         url: opts.url.href,
         responseType: opts.crawl ? 'text' : 'stream',
@@ -191,17 +192,40 @@ export class LinkChecker extends EventEmitter {
           validateStatus: () => true,
         });
       }
-
-      // Assume any 2xx status is 👌
-      status = res.status;
-      if (res.status >= 200 && res.status < 300) {
-        state = LinkState.OK;
-      }
-      data = res.data;
-      shouldRecurse = isHtml(res);
     } catch (err) {
       // request failure: invalid domain name, etc.
+      // this also occasionally catches too many redirects, but is still valid (e.g. https://www.ebay.com)
+      // for this reason, we also try doing a GET below to see if the link is valid
     }
+
+    try {
+      //some sites don't respond to a stream response type correctly, especially with a HEAD. Try a GET with a text response type
+      if (
+        (res === undefined || res.status < 200 || res.status >= 300) &&
+        !opts.crawl
+      ) {
+        res = await gaxios.request<string>({
+          method: 'GET',
+          url: opts.url.href,
+          responseType: 'text',
+          validateStatus: () => true,
+        });
+      }
+    } catch (ex) {
+      //catch the next failure
+    }
+
+    if (res !== undefined) {
+      status = res.status;
+      data = res.data;
+      shouldRecurse = isHtml(res);
+    }
+
+    // Assume any 2xx status is 👌
+    if (status >= 200 && status < 300) {
+      state = LinkState.OK;
+    }
+
     const result: LinkResult = {
       url: opts.url.href,
       status,

--- a/test/test.ts
+++ b/test/test.ts
@@ -280,4 +280,18 @@ describe('linkinator', () => {
     assert.ok(results.passed);
     assert.strictEqual(results.links.length, 2);
   });
+
+  it('should attempt a GET request if a HEAD request fails on external links', async () => {
+    const scopes = [
+      nock('http://fake.local')
+        .head('/')
+        .reply(403),
+      nock('http://fake.local')
+        .get('/')
+        .reply(200),
+    ];
+    const results = await check({ path: 'test/fixtures/basic' });
+    assert.ok(results.passed);
+    scopes.forEach(x => x.done());
+  });
 });


### PR DESCRIPTION
such as 'https://www.ebay.com.' This would cause link checking to fail for these sites. It seems like when it does a HEAD request on the site with a response type of 'stream,' it would get a bunch of redirects (over 100, which is the default for gaxios). Doing a simple GET request on the site worked correctly. We just need to make sure that we don't recursively crawl that site (opts.crawl should handle that).

I'm not 100% sure on response types and I did everything correctly, so it would be good to get another set of eyes on this.