### PR TITLE
feat: Add new queue for throttling requests

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,17 +45,26 @@ const cli = meow(
           Recursively follow links on the same root domain.
 
       --server-root
-          When scanning a locally directory, customize the location on disk 
+          When scanning a locally directory, customize the location on disk
           where the server is started.  Defaults to the path passed in [LOCATION].
 
       --silent
           Only output broken links
 
       --skip, -s
-          List of urls in regexy form to not include in the check.  
+          List of urls in regexy form to not include in the check.
 
       --timeout
           Request timeout in ms.  Defaults to 0 (no timeout).
+
+      --throttle
+      List of urls in regexy form to throttle in the check.
+
+      --throttlelimit
+      Maximum number of calls within an throttle internal.
+
+      --throttleinterval
+      Timespan for throttle limit in milliseconds with throttle urls.
 
     Examples
       $ linkinator docs/
@@ -75,6 +84,9 @@ const cli = meow(
       timeout: {type: 'number'},
       markdown: {type: 'boolean'},
       serverRoot: {type: 'string'},
+      throttle: {type: 'string'},
+      throttlelimit: {type: 'number'},
+      throttleinternal: {type: 'number'},
     },
     booleanDefault: undefined,
   }
@@ -126,12 +138,21 @@ async function main() {
     markdown: flags.markdown,
     concurrency: Number(flags.concurrency),
     serverRoot: flags.serverRoot,
+    throttleLimit: Number(flags.throttlelimit),
+    throttleInterval: Number(flags.throttleinterval)
   };
   if (flags.skip) {
     if (typeof flags.skip === 'string') {
       opts.linksToSkip = flags.skip.split(' ').filter(x => !!x);
     } else if (Array.isArray(flags.skip)) {
       opts.linksToSkip = flags.skip;
+    }
+  }
+  if (flags.throttle) {
+    if (typeof flags.throttle === 'string') {
+      opts.linksToThrottle = flags.throttle.split(' ').filter(x => !!x);
+    } else if (Array.isArray(flags.throttle)) {
+      opts.linksToThrottle = flags.throttle;
     }
   }
   const result = await checker.check(opts);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -139,7 +139,7 @@ async function main() {
     concurrency: Number(flags.concurrency),
     serverRoot: flags.serverRoot,
     throttleLimit: Number(flags.throttlelimit),
-    throttleInterval: Number(flags.throttleinterval)
+    throttleInterval: Number(flags.throttleinterval),
   };
   if (flags.skip) {
     if (typeof flags.skip === 'string') {

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,9 @@ export interface Flags {
   timeout?: number;
   markdown?: boolean;
   serverRoot?: string;
+  throttle?: string;
+  throttlelimit?: number;
+  throttleinterval?: number;
 }
 
 export async function getConfig(flags: Flags) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,6 @@ interface CrawlOptions {
  * Instance class used to perform a crawl job.
  */
 export class LinkChecker extends EventEmitter {
-
   /**
    * Crawl a given url or path, and return a list of visited links along with
    * status codes.
@@ -108,7 +107,7 @@ export class LinkChecker extends EventEmitter {
       concurrency: options.concurrency || 100,
       interval: opts.throttleInterval || 0,
       intervalCap: opts.throttleLimit || 1,
-      carryoverConcurrencyCount: true
+      carryoverConcurrencyCount: true,
     });
 
     const results = new Array<LinkResult>();
@@ -126,7 +125,7 @@ export class LinkChecker extends EventEmitter {
           cache: initCache,
           queue,
           tqueue,
-          rootPath: path
+          rootPath: path,
         });
       });
     }
@@ -432,13 +431,12 @@ export class LinkChecker extends EventEmitter {
 
           let throttle = false;
           if (Array.isArray(opts.checkOptions.linksToThrottle)) {
-            throttle = opts.checkOptions.linksToThrottle
-              .some((element) => {
-                if (result.url?.href) {
-                  return new RegExp(element).test(result.url.href);
-                }
-                return false;
-              });
+            throttle = opts.checkOptions.linksToThrottle.some(element => {
+              if (result.url?.href) {
+                return new RegExp(element).test(result.url.href);
+              }
+              return false;
+            });
           }
 
           const crawlJob = async () => {
@@ -451,9 +449,9 @@ export class LinkChecker extends EventEmitter {
               queue: opts.queue,
               tqueue: opts.tqueue,
               parent: opts.url.href,
-              rootPath: opts.rootPath
+              rootPath: opts.rootPath,
             });
-          }
+          };
 
           if (throttle) {
             opts.tqueue.add(crawlJob);


### PR DESCRIPTION
- Essentially add new settings throttle, throttlelimit and throttleinterval
  which configures secondary `tqueue` where things are added.
- New `tqueue` uses existing functionality in p-queue to timespan requests
  which effectively allows you to throttle and eventually wait
  that these secondary requests are done.
- Relates #179

If this looks to be useful, I could possibly add some tests instead of trying it manually.