### PR TITLE
feat: add verbosity flag to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,15 @@ $ linkinator LOCATIONS [ --arguments ]
         When scanning a locally directory, customize the location on disk
         where the server is started.  Defaults to the path passed in [LOCATION].
 
-    --silent
-        Only output broken links.
-
     --skip, -s
         List of urls in regexy form to not include in the check.
 
     --timeout
         Request timeout in ms.  Defaults to 0 (no timeout).
+
+    --verbosity
+        Override the default verbosity for this command. Available options are
+        'debug', 'info', 'warning', 'error', and 'none'.  Defaults to 'warning'.
 ```
 
 ### Command Examples

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,49 @@
+export enum LogLevel {
+  DEBUG = 0,
+  INFO = 1,
+  WARNING = 2,
+  ERROR = 3,
+  NONE = 4,
+}
+
+export enum Format {
+  TEXT,
+  JSON,
+  CSV,
+}
+
+export class Logger {
+  public level: LogLevel;
+  public format: Format;
+
+  constructor(level: LogLevel, format: Format) {
+    this.level = level;
+    this.format = format;
+  }
+
+  debug(message?: string) {
+    if (this.level <= LogLevel.DEBUG && this.format === Format.TEXT) {
+      console.debug(message);
+    }
+  }
+
+  info(message?: string) {
+    if (this.level <= LogLevel.INFO && this.format === Format.TEXT) {
+      console.info(message);
+    }
+  }
+
+  warn(message?: string) {
+    if (this.level <= LogLevel.WARNING && this.format === Format.TEXT) {
+      // note: this is `console.log` on purpose.  `console.warn` maps to
+      // `console.error`, which would print these messages to stderr.
+      console.log(message);
+    }
+  }
+
+  error(message?: string) {
+    if (this.level <= LogLevel.ERROR) {
+      console.error(message);
+    }
+  }
+}

--- a/test/zcli.ts
+++ b/test/zcli.ts
@@ -19,7 +19,7 @@ describe('cli', () => {
       'linkinator',
       'test/fixtures/markdown/README.md',
     ]);
-    assert.include(res.stdout, 'Successfully scanned');
+    assert.include(res.stderr, 'Successfully scanned');
   });
 
   it('should allow multiple paths', async () => {
@@ -28,7 +28,7 @@ describe('cli', () => {
       'test/fixtures/markdown/unlinked.md',
       'test/fixtures/markdown/README.md',
     ]);
-    assert.include(res.stdout, 'Successfully scanned');
+    assert.include(res.stderr, 'Successfully scanned');
   });
 
   it('should show help if no params are provided', async () => {
@@ -89,17 +89,16 @@ describe('cli', () => {
       'test/fixtures/markdown',
       'README.md',
     ]);
-    assert.ok(res.stdout.includes('Successfully scanned'));
+    assert.ok(res.stderr.includes('Successfully scanned'));
   });
 
   it('should accept globs', async () => {
     const res = await execa('npx', [
       'linkinator',
-      '--markdown',
       'test/fixtures/markdown/*.md',
       'test/fixtures/markdown/**/*.md',
     ]);
-    assert.ok(res.stdout.includes('Successfully scanned'));
+    assert.ok(res.stderr.includes('Successfully scanned'));
   });
 
   it('should throw on invalid format', async () => {

--- a/test/zcli.ts
+++ b/test/zcli.ts
@@ -17,7 +17,6 @@ describe('cli', () => {
   it('should pass successful markdown scan', async () => {
     const res = await execa('npx', [
       'linkinator',
-      '--markdown',
       'test/fixtures/markdown/README.md',
     ]);
     assert.include(res.stdout, 'Successfully scanned');
@@ -26,8 +25,7 @@ describe('cli', () => {
   it('should allow multiple paths', async () => {
     const res = await execa('npx', [
       'linkinator',
-      '--markdown',
-      'README.md',
+      'test/fixtures/markdown/unlinked.md',
       'test/fixtures/markdown/README.md',
     ]);
     assert.include(res.stdout, 'Successfully scanned');
@@ -43,7 +41,8 @@ describe('cli', () => {
   it('should flag skipped links', async () => {
     const res = await execa('npx', [
       'linkinator',
-      '--markdown',
+      '--verbosity',
+      'INFO',
       '--skip',
       'LICENSE.md',
       'test/fixtures/markdown/README.md',
@@ -76,7 +75,6 @@ describe('cli', () => {
   it('should not show links if --silent', async () => {
     const res = await execa('npx', [
       'linkinator',
-      '--markdown',
       '--silent',
       'test/fixtures/markdown/README.md',
     ]);
@@ -102,5 +100,62 @@ describe('cli', () => {
       'test/fixtures/markdown/**/*.md',
     ]);
     assert.ok(res.stdout.includes('Successfully scanned'));
+  });
+
+  it('should throw on invalid format', async () => {
+    const res = await execa(
+      'npx',
+      ['linkinator', './README.md', '--format', 'LOL'],
+      {
+        reject: false,
+      }
+    );
+    assert.include(res.stderr, 'FORMAT must be');
+  });
+
+  it('should throw on invalid format', async () => {
+    const res = await execa(
+      'npx',
+      ['linkinator', './README.md', '--format', 'LOL'],
+      {
+        reject: false,
+      }
+    );
+    assert.include(res.stderr, 'FORMAT must be');
+  });
+
+  it('should throw on invalid verbosity', async () => {
+    const res = await execa(
+      'npx',
+      ['linkinator', './README.md', '--VERBOSITY', 'LOL'],
+      {
+        reject: false,
+      }
+    );
+    assert.include(res.stderr, 'VERBOSITY must be');
+  });
+
+  it('should throw when verbosity and silent are flagged', async () => {
+    const res = await execa(
+      'npx',
+      ['linkinator', './README.md', '--verbosity', 'DEBUG', '--silent'],
+      {
+        reject: false,
+      }
+    );
+    assert.include(res.stderr, 'The SILENT and VERBOSITY flags');
+  });
+
+  it('should show no output for verbosity=NONE', async () => {
+    const res = await execa(
+      'npx',
+      ['linkinator', 'test/fixtures/basic', '--verbosity', 'NONE'],
+      {
+        reject: false,
+      }
+    );
+    assert.strictEqual(res.exitCode, 1);
+    assert.strictEqual(res.stdout, '');
+    assert.strictEqual(res.stderr, '');
   });
 });


### PR DESCRIPTION
Fixes #213.  This adds a `--verbosity` flag, which defaults to `WARNING`.  Skipped links now are hidden by default, unless verbosity is set to `INFO` or `DEBUG`. 