### PR TITLE
fix: map paths in results back to filesystem

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -19,14 +19,19 @@ export interface CheckOptions {
   retry?: boolean;
 }
 
+export interface InternalCheckOptions extends CheckOptions {
+  syntheticServerRoot?: string;
+  staticHttpServerHost?: string;
+}
+
 /**
  * Validate the provided flags all work with each other.
  * @param options CheckOptions passed in from the CLI (or API)
  */
 export async function processOptions(
   opts: CheckOptions
-): Promise<CheckOptions> {
-  const options = Object.assign({}, opts);
+): Promise<InternalCheckOptions> {
+  const options = Object.assign({}, opts) as InternalCheckOptions;
 
   // ensure at least one path is provided
   if (options.path.length === 0) {
@@ -131,6 +136,7 @@ export async function processOptions(
         options.serverRoot = options.path[0];
         options.path = '/';
       }
+      options.syntheticServerRoot = options.serverRoot;
     }
   }
   return options;

--- a/test/test.cli.ts
+++ b/test/test.cli.ts
@@ -75,7 +75,7 @@ describe('cli', function () {
       'csv',
       'test/fixtures/markdown/README.md',
     ]);
-    assert.match(res.stdout, /\/README.md,200,OK,/);
+    assert.match(res.stdout, /README.md,200,OK,/);
   });
 
   it('should provide JSON if asked nicely', async () => {

--- a/test/test.index.ts
+++ b/test/test.index.ts
@@ -395,6 +395,9 @@ describe('linkinator', () => {
     });
     assert.ok(results.passed);
     assert.strictEqual(results.links.length, 6);
+    const licenseLink = results.links.find(x => x.url.endsWith('LICENSE.md'));
+    assert.ok(licenseLink);
+    assert.strictEqual(licenseLink.url, 'test/fixtures/markdown/LICENSE.md');
   });
 
   it('should autoscan markdown if specifically in path', async () => {
@@ -496,5 +499,28 @@ describe('linkinator', () => {
     });
     assert.ok(!results.passed);
     assert.strictEqual(results.links.length, 3);
+  });
+
+  it('should provide a relative path in the results', async () => {
+    const scope = nock('http://fake.local').head('/').reply(200);
+    const results = await check({path: 'test/fixtures/basic'});
+    assert.strictEqual(results.links.length, 2);
+    const [rootLink, fakeLink] = results.links;
+    assert.strictEqual(rootLink.url, 'test/fixtures/basic');
+    assert.strictEqual(fakeLink.url, 'http://fake.local/');
+    scope.done();
+  });
+
+  it('should provide a server root relative path in the results', async () => {
+    const scope = nock('http://fake.local').head('/').reply(200);
+    const results = await check({
+      path: '.',
+      serverRoot: 'test/fixtures/basic',
+    });
+    assert.strictEqual(results.links.length, 2);
+    const [rootLink, fakeLink] = results.links;
+    assert.strictEqual(rootLink.url, `.${path.sep}`);
+    assert.strictEqual(fakeLink.url, 'http://fake.local/');
+    scope.done();
   });
 });

--- a/test/test.index.ts
+++ b/test/test.index.ts
@@ -506,7 +506,7 @@ describe('linkinator', () => {
     const results = await check({path: 'test/fixtures/basic'});
     assert.strictEqual(results.links.length, 2);
     const [rootLink, fakeLink] = results.links;
-    assert.strictEqual(rootLink.url, 'test/fixtures/basic');
+    assert.strictEqual(rootLink.url, path.join('test', 'fixtures', 'basic'));
     assert.strictEqual(fakeLink.url, 'http://fake.local/');
     scope.done();
   });


### PR DESCRIPTION
Fixes https://github.com/JustinBeckwith/linkinator/issues/166.  This updates the returned paths in the results to map to the filesystem if a local path was given.  