### PR TITLE
build: Add CodeQL scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,34 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches:
+      - master
+      - "!renovate/**"
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches:
+      - master
+  schedule:
+    - cron: "0 0 * * 0"
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: "javascript"
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
CodeQL is the successor of [LGTM](https://lgtm.com). It checks for some common security issues.

Not sure if you have access to my fork actions/security tab so here's a screenshot:

![image](https://user-images.githubusercontent.com/349621/104117837-14a62a80-532d-11eb-8dc3-9a094dce6325.png)

Feel free to adapt the cron job and the branches :)