### PR TITLE
build: disable package-lock.json properly

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
The default setting is to always generate a package-lock.json file, so this step is required to prevent its generation.

For what is worth without the lock file we can't use caching properly on CI. Not that it's a huge deal, but it could speed things up a bit.