### PR TITLE
build: fix release action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
       - run: npm install
       - run: npm run docs-test
   release:
-    if: github.ref == 'refs/heads/master'
+    if: github.repository == 'JustinBeckwith/linkinator' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     needs: [test, lint]
     steps:


### PR DESCRIPTION
When we are not on the upstream repo, don't run the release action

I was getting failures on my fork and it probably makes sense to skip the release action if not on upstream.