### PR TITLE
build: Enable a couple more ESLint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,17 @@
 {
-  "extends": "./node_modules/gts"
-}
+  "extends": "./node_modules/gts",
+  "rules": {
+    "dot-notation": "error",
+    "no-else-return": [
+      "error",
+      {
+        "allowElseIf": false
+      }
+    ],
+    "no-lonely-if": "error",
+    "no-undef-init": "error",
+    "no-useless-return": "error",
+    "prefer-object-spread": "error",
+    "prefer-spread": "error"
+      }
+    }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "extends": "./node_modules/gts",
   "rules": {
-    "dot-notation": "error",
+    "dot-notation": "off",
     "no-else-return": [
       "error",
       {
@@ -13,5 +13,25 @@
     "no-useless-return": "error",
     "prefer-object-spread": "error",
     "prefer-spread": "error"
+  },
+  "overrides": [
+    {
+      "files": [
+        "**/*.ts",
+        "**/*.tsx"
+      ],
+      "parser": "@typescript-eslint/parser",
+      "parserOptions": {
+        "project": "./tsconfig.json"
+      },
+      "rules": {
+        "@typescript-eslint/dot-notation": "error",
+        "@typescript-eslint/no-unnecessary-type-assertion": "error",
+        "@typescript-eslint/prefer-for-of": "error",
+        "@typescript-eslint/prefer-includes": "error",
+        "@typescript-eslint/prefer-readonly": "error",
+        "@typescript-eslint/promise-function-async": "error"
       }
     }
+  ]
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -210,15 +210,11 @@ async function main() {
       if (link.state === LinkState.BROKEN) {
         return true;
       }
-      if (link.state === LinkState.OK) {
-        if (verbosity <= LogLevel.WARNING) {
-          return true;
-        }
+      if (link.state === LinkState.OK && verbosity <= LogLevel.WARNING) {
+        return true;
       }
-      if (link.state === LinkState.SKIPPED) {
-        if (verbosity <= LogLevel.INFO) {
-          return true;
-        }
+      if (link.state === LinkState.SKIPPED && verbosity <= LogLevel.INFO) {
+        return true;
       }
       return false;
     });

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,7 +38,7 @@ export async function getConfig(flags: Flags) {
   // `meow` is set up to pass boolean flags as `undefined` if not passed.
   // copy the struct, and delete properties that are `undefined` so the merge
   // doesn't blast away config level settings.
-  const strippedFlags = Object.assign({}, flags);
+  const strippedFlags = {...flags};
   Object.entries(strippedFlags).forEach(([key, value]) => {
     if (typeof value === 'undefined') {
       delete (strippedFlags as {[index: string]: {}})[key];
@@ -47,6 +47,6 @@ export async function getConfig(flags: Flags) {
 
   // combine the flags passed on the CLI with the flags in the config file,
   // with CLI flags getting precedence
-  config = Object.assign({}, config, strippedFlags);
+  config = {...config, ...strippedFlags};
   return config;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -214,7 +214,7 @@ export class LinkChecker extends EventEmitter {
     let state = LinkState.BROKEN;
     let data = '';
     let shouldRecurse = false;
-    let res: GaxiosResponse<string> | undefined = undefined;
+    let res: GaxiosResponse<string> | undefined;
     const failures: {}[] = [];
     try {
       res = await request<string>({

--- a/src/index.ts
+++ b/src/index.ts
@@ -371,9 +371,9 @@ export class LinkChecker extends EventEmitter {
     // The `retry-after` header can come in either <seconds> or
     // A specific date to go check.
     let retryAfter = Number(retryAfterRaw) * 1000 + Date.now();
-    if (isNaN(retryAfter)) {
+    if (Number.isNaN(retryAfter)) {
       retryAfter = Date.parse(retryAfterRaw);
-      if (isNaN(retryAfter)) {
+      if (Number.isNaN(retryAfter)) {
         return false;
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -315,14 +315,15 @@ export class LinkChecker extends EventEmitter {
           continue;
         }
 
-        let crawl = (opts.checkOptions.recurse! &&
-          result.url?.href.startsWith(opts.rootPath)) as boolean;
+        let crawl =
+          opts.checkOptions.recurse! &&
+          result.url?.href.startsWith(opts.rootPath);
 
         // only crawl links that start with the same host
         if (crawl) {
           try {
             const pathUrl = new URL(opts.rootPath);
-            crawl = result.url!.host === pathUrl.host;
+            crawl = result.url.host === pathUrl.host;
           } catch {
             // ignore errors
           }
@@ -459,5 +460,5 @@ function mapUrl(url?: string, options?: InternalCheckOptions): string {
       newUrl = `.${path.sep}`;
     }
   }
-  return newUrl!;
+  return newUrl;
 }

--- a/src/links.ts
+++ b/src/links.ts
@@ -57,16 +57,16 @@ export function getLinks(source: string, baseUrl: string): ParsedUrl[] {
       const relValuesToIgnore = ['dns-prefetch', 'preconnect'];
       if (
         element.tagName === 'link' &&
-        relValuesToIgnore.includes(element.attribs['rel'])
+        relValuesToIgnore.includes(element.attribs.rel)
       ) {
         return;
       }
 
       // Only for <meta content=""> tags, only validate the url if
       // the content actually looks like a url
-      if (element.tagName === 'meta' && element.attribs['content']) {
+      if (element.tagName === 'meta' && element.attribs.content) {
         try {
-          new URL(element.attribs['content']);
+          new URL(element.attribs.content);
         } catch (e) {
           return;
         }

--- a/src/options.ts
+++ b/src/options.ts
@@ -31,7 +31,7 @@ export interface InternalCheckOptions extends CheckOptions {
 export async function processOptions(
   opts: CheckOptions
 ): Promise<InternalCheckOptions> {
-  const options = Object.assign({}, opts) as InternalCheckOptions;
+  const options = {...opts} as InternalCheckOptions;
 
   // ensure at least one path is provided
   if (options.path.length === 0) {
@@ -50,7 +50,7 @@ export async function processOptions(
 
   // Ensure we do not mix http:// and file system paths.  The paths passed in
   // must all be filesystem paths, or HTTP paths.
-  let isUrlType: boolean | undefined = undefined;
+  let isUrlType: boolean | undefined;
   for (const path of options.path) {
     const innerIsUrlType = path.startsWith('http');
     if (isUrlType === undefined) {

--- a/src/options.ts
+++ b/src/options.ts
@@ -130,8 +130,7 @@ export async function processOptions(
       if (s.isFile()) {
         const pathParts = options.path[0].split(path.sep);
         options.path = [path.join('.', pathParts[pathParts.length - 1])];
-        options.serverRoot =
-          pathParts.slice(0, pathParts.length - 1).join(path.sep) || '.';
+        options.serverRoot = pathParts.slice(0, -1).join(path.sep) || '.';
       } else {
         options.serverRoot = options.path[0];
         options.path = '/';

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -20,9 +20,9 @@ export declare interface Queue {
 export type AsyncFunction = () => Promise<void>;
 
 export class Queue extends EventEmitter {
-  private q: Array<QueueItem> = [];
+  private readonly q: Array<QueueItem> = [];
   private activeFunctions = 0;
-  private concurrency: number;
+  private readonly concurrency: number;
 
   constructor(options: QueueOptions) {
     super();

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,7 +32,7 @@ export async function startWebServer(options: WebServerOptions) {
   const root = path.resolve(options.root);
   return new Promise<http.Server>((resolve, reject) => {
     const server = http
-      .createServer((req, res) => handleRequest(req, res, root, options))
+      .createServer(async (req, res) => handleRequest(req, res, root, options))
       .listen(options.port, () => resolve(server))
       .on('error', reject);
     enableDestroy(server);

--- a/test/test.index.ts
+++ b/test/test.index.ts
@@ -134,8 +134,7 @@ describe('linkinator', () => {
       },
     ];
 
-    for (let i = 0; i < cases.length; i++) {
-      const {fixture, nonBrokenUrl} = cases[i];
+    for (const {fixture, nonBrokenUrl} of cases) {
       const scope = nock('http://fake.local')
         .get('/pageBase/index')
         .replyWithFile(200, fixture, {

--- a/test/test.index.ts
+++ b/test/test.index.ts
@@ -59,7 +59,7 @@ describe('linkinator', () => {
     const scope = nock('https://good.com').head('/').reply(200);
     const results = await check({
       path: 'test/fixtures/filter',
-      linksToSkip: link => Promise.resolve(link.includes('filterme')),
+      linksToSkip: async link => Promise.resolve(link.includes('filterme')),
     });
     assert.ok(results.passed);
     assert.strictEqual(


### PR DESCRIPTION
* dot-notation
* no-else-return
* no-lonely-if
* no-undef-init
* no-useless-return
* prefer-object-spread
* prefer-spread

TODO:

- [x] Verify if any of those are already enabled in the inherited configs
- [x] Enable the following rules too (I'm having trouble with these since `typescript-eslint` needs some kind of extra step):
  - [x] `@typescript-eslint/no-unnecessary-type-assertion`
  - [x] `@typescript-eslint/prefer-includes`
  - [x] `@typescript-eslint/prefer-for-of`
  - [x] `@typescript-eslint/prefer-readonly`
  - [x] `@typescript-eslint/promise-function-async`
- [x] Replace `dot-notation` with `@typescript-eslint/dot-notation`

Non-whitespace diff: <https://github.com/JustinBeckwith/linkinator/pull/244/files?w=1>

For later:

- [ ] optional catch binding