### PR TITLE
Remove chai

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -514,12 +514,6 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
-    "@types/chai": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.14.tgz",
-      "integrity": "sha512-G+ITQPXkwTrslfG5L/BksmbLUA0M1iybEsmCWPqzSxsRRhJZimBKJkoMi8fr/CPygPTj4zO5pJH7I2/cm9M7SQ==",
-      "dev": true
-    },
     "@types/cheerio": {
       "version": "0.22.23",
       "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.23.tgz",
@@ -938,12 +932,6 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
-    "assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true
-    },
     "astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -1203,20 +1191,6 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
-    "chai": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
-      "dev": true,
-      "requires": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
-        "get-func-name": "^2.0.0",
-        "pathval": "^1.1.0",
-        "type-detect": "^4.0.5"
-      }
-    },
     "chalk": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
@@ -1230,12 +1204,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true
-    },
-    "check-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "cheerio": {
@@ -1676,15 +1644,6 @@
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "requires": {
         "mimic-response": "^1.0.0"
-      }
-    },
-    "deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-      "dev": true,
-      "requires": {
-        "type-detect": "^4.0.0"
       }
     },
     "deep-extend": {
@@ -2497,12 +2456,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
-    },
-    "get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "get-stdin": {
@@ -7687,12 +7640,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true
-    },
-    "pathval": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
     "performance-now": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "update-notifier": "^5.0.0"
   },
   "devDependencies": {
-    "@types/chai": "^4.2.7",
     "@types/cheerio": "0.22.23",
     "@types/glob": "^7.1.3",
     "@types/marked": "^1.2.0",
@@ -46,7 +45,6 @@
     "@types/sinon": "^9.0.0",
     "@types/update-notifier": "^5.0.0",
     "c8": "^7.0.0",
-    "chai": "^4.2.0",
     "execa": "^5.0.0",
     "gts": "^3.0.0",
     "mocha": "^8.0.0",

--- a/test/test.cli.ts
+++ b/test/test.cli.ts
@@ -1,8 +1,8 @@
-import {describe, it} from 'mocha';
-import * as execa from 'execa';
-import {assert} from 'chai';
+import * as assert from 'assert';
 import * as http from 'http';
 import * as util from 'util';
+import * as execa from 'execa';
+import {describe, it} from 'mocha';
 import enableDestroy = require('server-destroy');
 import {LinkResult, LinkState} from '../src/index';
 
@@ -29,12 +29,12 @@ describe('cli', function () {
     const res = await execa('linkinator', ['test/fixtures/basic'], {
       reject: false,
     });
-    assert.match(res.stderr, /ERROR: Detected 1 broken links/);
+    assert.ok(res.stderr.includes('ERROR: Detected 1 broken links'));
   });
 
   it('should pass successful markdown scan', async () => {
     const res = await execa('linkinator', ['test/fixtures/markdown/README.md']);
-    assert.match(res.stderr, /Successfully scanned/);
+    assert.ok(res.stderr.includes('Successfully scanned'));
   });
 
   it('should allow multiple paths', async () => {
@@ -42,14 +42,14 @@ describe('cli', function () {
       'test/fixtures/markdown/unlinked.md',
       'test/fixtures/markdown/README.md',
     ]);
-    assert.match(res.stderr, /Successfully scanned/);
+    assert.ok(res.stderr.includes('Successfully scanned'));
   });
 
   it('should show help if no params are provided', async () => {
     const res = await execa('linkinator', {
       reject: false,
     });
-    assert.match(res.stdout, /\$ linkinator LOCATION \[ --arguments \]/);
+    assert.ok(res.stdout.includes('$ linkinator LOCATION [ --arguments ]'));
   });
 
   it('should flag skipped links', async () => {
@@ -60,7 +60,7 @@ describe('cli', function () {
       '"LICENSE.md, unlinked.md"',
       'test/fixtures/markdown/README.md',
     ]);
-    assert.match(res.stdout, /\[SKP\]/);
+    assert.ok(res.stdout.includes('[SKP]'));
   });
 
   it('should provide CSV if asked nicely', async () => {
@@ -69,7 +69,7 @@ describe('cli', function () {
       'csv',
       'test/fixtures/markdown/README.md',
     ]);
-    assert.match(res.stdout, /README.md,200,OK,/);
+    assert.ok(res.stdout.includes('README.md,200,OK,'));
   });
 
   it('should provide JSON if asked nicely', async () => {
@@ -87,7 +87,7 @@ describe('cli', function () {
       '--silent',
       'test/fixtures/markdown/README.md',
     ]);
-    assert.notMatch(res.stdout, /\[/);
+    assert.ok(!res.stdout.includes('['));
   });
 
   it('should not show 200 links if verbosity is ERROR with JSON', async () => {
@@ -111,7 +111,7 @@ describe('cli', function () {
       'test/fixtures/markdown',
       'README.md',
     ]);
-    assert.match(res.stderr, /Successfully scanned/);
+    assert.ok(res.stderr.includes('Successfully scanned'));
   });
 
   it('should accept globs', async () => {
@@ -119,14 +119,14 @@ describe('cli', function () {
       'test/fixtures/markdown/*.md',
       'test/fixtures/markdown/**/*.md',
     ]);
-    assert.match(res.stderr, /Successfully scanned/);
+    assert.ok(res.stderr.includes('Successfully scanned'));
   });
 
   it('should throw on invalid format', async () => {
     const res = await execa('linkinator', ['./README.md', '--format', 'LOL'], {
       reject: false,
     });
-    assert.match(res.stderr, /FORMAT must be/);
+    assert.ok(res.stderr.includes('FORMAT must be'));
   });
 
   it('should throw on invalid verbosity', async () => {
@@ -137,7 +137,7 @@ describe('cli', function () {
         reject: false,
       }
     );
-    assert.match(res.stderr, /VERBOSITY must be/);
+    assert.ok(res.stderr.includes('VERBOSITY must be'));
   });
 
   it('should throw when verbosity and silent are flagged', async () => {
@@ -148,7 +148,7 @@ describe('cli', function () {
         reject: false,
       }
     );
-    assert.match(res.stderr, /The SILENT and VERBOSITY flags/);
+    assert.ok(res.stderr.includes('The SILENT and VERBOSITY flags'));
   });
 
   it('should show no output for verbosity=NONE', async () => {
@@ -173,7 +173,7 @@ describe('cli', function () {
       }
     );
     assert.strictEqual(res.exitCode, 1);
-    assert.match(res.stdout, /reason: getaddrinfo/);
+    assert.ok(res.stdout.includes('reason: getaddrinfo'));
   });
 
   it('should allow passing a config', async () => {
@@ -199,7 +199,7 @@ describe('cli', function () {
         requestCount++;
         firstRequestTime = Date.now();
       } else {
-        assert.isAtLeast(Date.now(), firstRequestTime + delayMillis);
+        assert.ok(Date.now() >= firstRequestTime + delayMillis);
         res.writeHead(200);
       }
       res.end();
@@ -212,6 +212,6 @@ describe('cli', function () {
       'test/fixtures/retryCLI',
     ]);
     assert.strictEqual(res.exitCode, 0);
-    assert.include(res.stdout, `Retrying: http://localhost:${port}`);
+    assert.ok(res.stdout.includes(`Retrying: http://localhost:${port}`));
   });
 });

--- a/test/test.retry.ts
+++ b/test/test.retry.ts
@@ -1,4 +1,4 @@
-import {assert} from 'chai';
+import * as assert from 'assert';
 import * as nock from 'nock';
 import * as sinon from 'sinon';
 import {describe, it, afterEach} from 'mocha';
@@ -104,12 +104,12 @@ describe('retries', () => {
         'retry-after': '3',
       })
       .get('/1', () => {
-        assert.isAtLeast(Date.now(), 3000);
+        assert.ok(Date.now() >= 3000);
         return true;
       })
       .reply(200)
       .get('/2', () => {
-        assert.isAtLeast(Date.now(), 3000);
+        assert.ok(Date.now() >= 3000);
         return true;
       })
       .reply(200)
@@ -118,7 +118,7 @@ describe('retries', () => {
         'retry-after': '3',
       })
       .get('/3', () => {
-        assert.isAtLeast(Date.now(), 3000);
+        assert.ok(Date.now() >= 3000);
         return true;
       })
       .reply(200);
@@ -149,12 +149,12 @@ describe('retries', () => {
         // make sure the /3 route reset it to 9 seconds here. This is common
         // when a flood of requests come through and the retry-after gets
         // extended.
-        assert.isAtLeast(Date.now(), 9000);
+        assert.ok(Date.now() >= 9000);
         return true;
       })
       .reply(200)
       .get('/2', () => {
-        assert.isAtLeast(Date.now(), 9000);
+        assert.ok(Date.now() >= 9000);
         return true;
       })
       .reply(200)
@@ -163,7 +163,7 @@ describe('retries', () => {
         'retry-after': '9',
       })
       .get('/3', () => {
-        assert.isAtLeast(Date.now(), 9000);
+        assert.ok(Date.now() >= 9000);
         return true;
       })
       .reply(200);


### PR DESCRIPTION
Not a big improvement, but it seems we can just do everything without it.

I went with `assert.ok` but we could use `strictEqual` too.