### PR TITLE
build: remove `npm link` from `docs-test` too

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "fix": "gts fix",
     "lint": "gts lint",
     "build-binaries": "pkg . --out-path build/binaries",
-    "docs-test": "npm link && linkinator ./README.md"
+    "docs-test": "node build/src/cli.js ./README.md"
   },
   "dependencies": {
     "chalk": "^4.0.0",


### PR DESCRIPTION
I don't know of any way to reuse the bin script here in a cross-platform way, so this might be a little repetitive, but works everywhere and it's fast, without messing with the system.