### PR TITLE
build: remove compile from release workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,7 +91,6 @@ jobs:
             ${{ runner.os }}-node-v${{ env.NODE }}-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
             ${{ runner.os }}-node-v${{ env.NODE }}-
       - run: npm ci
-      - run: npm run compile
       - run: npm run build-binaries
       - run: npx semantic-release
         env:


### PR DESCRIPTION
`compile` is set to run in `prepare` so it already runs after `npm ci`. Without this, compile runs twice.

This reminds me, `needs: [test, lint]`: should this include Windows etc?