### PR TITLE
chore: add html reporter too in c8

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,10 @@
   "c8": {
     "exclude": [
       "build/test"
+    ],
+    "reporter": [
+      "html",
+      "text"
     ]
   }
 }


### PR DESCRIPTION
* html, so that we get nice browseable report, mostly useful locally
* text, for the CLI output

This should match the previous behavior + add the html reporter.