### PR TITLE
fix: ignore query strings in the local server

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -45,10 +45,11 @@ async function handleRequest(
   root: string,
   options: WebServerOptions
 ) {
-  const pathParts = new URL(req.url || '', 'http://abc').pathname.split('/');
+  const url = new URL(req.url || '/', `http://localhost:${options.port}`);
+  const pathParts = url.pathname.split('/');
   const originalPath = path.join(root, ...pathParts);
-  if (req.url?.endsWith('/')) {
-    pathParts.push('index.html');
+  if (pathParts[pathParts.length - 1] == '') {
+    pathParts[pathParts.length - 1] = 'index.html';
   }
   const localPath = path.join(root, ...pathParts);
   const maybeListing =

--- a/src/server.ts
+++ b/src/server.ts
@@ -51,11 +51,6 @@ async function handleRequest(
     pathParts.push('index.html');
   }
   const localPath = path.join(root, ...pathParts);
-  if (!localPath.startsWith(root)) {
-    res.writeHead(500);
-    res.end();
-    return;
-  }
   const maybeListing =
     options.directoryListing && localPath.endsWith(`${path.sep}index.html`);
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -44,7 +44,7 @@ async function handleRequest(
   root: string,
   options: WebServerOptions
 ) {
-  const pathParts = req.url?.split('/') || [];
+  const pathParts = new URL(req.url || '', 'http://abc').pathname.split('/');
   const originalPath = path.join(root, ...pathParts);
   if (req.url?.endsWith('/')) {
     pathParts.push('index.html');

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import {promisify} from 'util';
 import * as marked from 'marked';
 import * as mime from 'mime';
+import {URL} from 'url';
 import escape = require('escape-html');
 import enableDestroy = require('server-destroy');
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -48,7 +48,7 @@ async function handleRequest(
   const url = new URL(req.url || '/', `http://localhost:${options.port}`);
   const pathParts = url.pathname.split('/');
   const originalPath = path.join(root, ...pathParts);
-  if (pathParts[pathParts.length - 1] == '') {
+  if (pathParts[pathParts.length - 1] === '') {
     pathParts[pathParts.length - 1] = 'index.html';
   }
   const localPath = path.join(root, ...pathParts);

--- a/test/test.server.ts
+++ b/test/test.server.ts
@@ -44,9 +44,9 @@ describe('server', () => {
   });
 
   it('should protect against path escape attacks', async () => {
-    const url = `${rootUrl}/../../etc/passwd`;
+    const url = `${rootUrl}/../server/index.html`;
     const res = await request({url, validateStatus: () => true});
-    assert.strictEqual(res.status, 500);
+    assert.strictEqual(res.status, 404);
   });
 
   it('should return a 404 for missing paths', async () => {
@@ -57,6 +57,13 @@ describe('server', () => {
 
   it('should work with directories with a .', async () => {
     const url = `${rootUrl}/5.0/`;
+    const res = await request({url});
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.data, contents);
+  });
+
+  it('should ignore query strings', async () => {
+    const url = `${rootUrl}/index.html?a=b`;
     const res = await request({url});
     assert.strictEqual(res.status, 200);
     assert.strictEqual(res.data, contents);

--- a/test/test.server.ts
+++ b/test/test.server.ts
@@ -68,4 +68,11 @@ describe('server', () => {
     assert.strictEqual(res.status, 200);
     assert.strictEqual(res.data, contents);
   });
+
+  it('should ignore query strings in a directory', async () => {
+    const url = `${rootUrl}/?a=b`;
+    const res = await request({url});
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.data, contents);
+  });
 });


### PR DESCRIPTION
A "local server" link that includes a query string would fail (because the query string would be interpreted as part of the filename.) This recently started breaking Ruby builds because the Ruby doc generator recently started generating some links with a query string.

This change removes the query string in the local server implementation, by parsing the request URL and taking only the pathname field as the file path. Note that it also changes the behavior in the event of a path escape attack attempt, since URL does not allow navigation above the root, so this PR also removes the now-redundant check and updates the appropriate test case.
