### PR TITLE
fix: handle querystring parameters in path

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -129,7 +129,7 @@ export async function processOptions(
       options.serverRoot = options.path[0];
       if (s.isFile()) {
         const pathParts = options.path[0].split(path.sep);
-        options.path = [path.sep + pathParts[pathParts.length - 1]];
+        options.path = [path.join('.', pathParts[pathParts.length - 1])];
         options.serverRoot =
           pathParts.slice(0, pathParts.length - 1).join(path.sep) || '.';
       } else {

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import {promisify} from 'util';
 import * as marked from 'marked';
 import * as mime from 'mime';
+import {URL} from 'url';
 import escape = require('escape-html');
 import enableDestroy = require('server-destroy');
 
@@ -44,9 +45,10 @@ async function handleRequest(
   root: string,
   options: WebServerOptions
 ) {
-  const pathParts = req.url?.split('/') || [];
+  const url = new URL(req.url || '/', `http://localhost:${options.port}`);
+  const pathParts = url.pathname.split('/').filter(x => !!x);
   const originalPath = path.join(root, ...pathParts);
-  if (req.url?.endsWith('/')) {
+  if (url.pathname.endsWith('/')) {
     pathParts.push('index.html');
   }
   const localPath = path.join(root, ...pathParts);

--- a/test/test.server.ts
+++ b/test/test.server.ts
@@ -46,7 +46,7 @@ describe('server', () => {
   it('should protect against path escape attacks', async () => {
     const url = `${rootUrl}/../../etc/passwd`;
     const res = await request({url, validateStatus: () => true});
-    assert.strictEqual(res.status, 500);
+    assert.strictEqual(res.status, 404);
   });
 
   it('should return a 404 for missing paths', async () => {
@@ -57,6 +57,20 @@ describe('server', () => {
 
   it('should work with directories with a .', async () => {
     const url = `${rootUrl}/5.0/`;
+    const res = await request({url});
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.data, contents);
+  });
+
+  it('should ignore query strings', async () => {
+    const url = `${rootUrl}/index.html?a=b`;
+    const res = await request({url});
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.data, contents);
+  });
+
+  it('should ignore query strings in a directory', async () => {
+    const url = `${rootUrl}/?a=b`;
     const res = await request({url});
     assert.strictEqual(res.status, 200);
     assert.strictEqual(res.data, contents);


### PR DESCRIPTION
Shout out to @dazuma who did the heavy lifting here, turns out I had to fix a weird windows path bug along the way, so landing here. 