### PR TITLE
fix: do not include skipped links in the final link count

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -246,7 +246,7 @@ async function main() {
   }
 
   const total = (Date.now() - start) / 1000;
-
+  const scannedLinks = result.links.filter(x => x.state !== LinkState.SKIPPED);
   if (!result.passed) {
     const borked = result.links.filter(x => x.state === LinkState.BROKEN);
     logger.error(
@@ -254,7 +254,7 @@ async function main() {
         `${chalk.red('ERROR')}: Detected ${
           borked.length
         } broken links. Scanned ${chalk.yellow(
-          result.links.length.toString()
+          scannedLinks.length.toString()
         )} links in ${chalk.cyan(total.toString())} seconds.`
       )
     );
@@ -264,7 +264,7 @@ async function main() {
   logger.error(
     chalk.bold(
       `🤖 Successfully scanned ${chalk.green(
-        result.links.length.toString()
+        scannedLinks.length.toString()
       )} links in ${chalk.cyan(total.toString())} seconds.`
     )
   );

--- a/test/test.cli.ts
+++ b/test/test.cli.ts
@@ -62,7 +62,11 @@ describe('cli', function () {
       '"LICENSE.md, unlinked.md"',
       'test/fixtures/markdown/README.md',
     ]);
-    assert.match(stripAnsi(res.stdout), /\[SKP\]/);
+    const stdout = stripAnsi(res.stdout);
+    const stderr = stripAnsi(res.stderr);
+    assert.match(stdout, /\[SKP\]/);
+    // make sure we don't report skipped links in the count
+    assert.match(stderr, /scanned 2 links/);
   });
 
   it('should provide CSV if asked nicely', async () => {


### PR DESCRIPTION
I suspect this is part of what's happening in https://github.com/JustinBeckwith/linkinator-action/issues/42