### PR TITLE
fix(perf): refactor to use htmlparser2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -495,15 +495,6 @@
       "integrity": "sha512-yd+9qKmJxm496BOV9CMNaey8TWsikaZOwMRwPHQIjcOJM9oV+fi9ZMNw3JsVnbEEbo2gRTDnGEBv8pjyn67hNg==",
       "dev": true
     },
-    "@types/cheerio": {
-      "version": "0.22.30",
-      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.30.tgz",
-      "integrity": "sha512-t7ZVArWZlq3dFa9Yt33qFBQIK4CQd1Q3UJp0V+UhP6vgLWLM6Qug7vZuRSGXg45zXeB1Fm5X2vmBkEX58LV2Tw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/configstore": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@types/configstore/-/configstore-5.0.1.tgz",
@@ -1027,11 +1018,6 @@
         }
       }
     },
-    "boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
-    },
     "bottleneck": {
       "version": "2.19.5",
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
@@ -1252,32 +1238,6 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
-    },
-    "cheerio": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.10.tgz",
-      "integrity": "sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==",
-      "requires": {
-        "cheerio-select": "^1.5.0",
-        "dom-serializer": "^1.3.2",
-        "domhandler": "^4.2.0",
-        "htmlparser2": "^6.1.0",
-        "parse5": "^6.0.1",
-        "parse5-htmlparser2-tree-adapter": "^6.0.1",
-        "tslib": "^2.2.0"
-      }
-    },
-    "cheerio-select": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.5.0.tgz",
-      "integrity": "sha512-qocaHPv5ypefh6YNxvnbABM07KMxExbtbfuJoIie3iZXX1ERwYmJcIiRrr9H05ucQP1k28dav8rpdDgjQd8drg==",
-      "requires": {
-        "css-select": "^4.1.3",
-        "css-what": "^5.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0",
-        "domutils": "^2.7.0"
-      }
     },
     "chokidar": {
       "version": "3.5.1",
@@ -1579,23 +1539,6 @@
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
     },
-    "css-select": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
-      "integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
-      "requires": {
-        "boolbase": "^1.0.0",
-        "css-what": "^5.0.0",
-        "domhandler": "^4.2.0",
-        "domutils": "^2.6.0",
-        "nth-check": "^2.0.0"
-      }
-    },
-    "css-what": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
-      "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg=="
-    },
     "dateformat": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
@@ -1741,6 +1684,13 @@
         "domelementtype": "^2.0.1",
         "domhandler": "^4.2.0",
         "entities": "^2.0.0"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+        }
       }
     },
     "domelementtype": {
@@ -1749,17 +1699,17 @@
       "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
     },
     "domhandler": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
-      "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
+      "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
       "requires": {
         "domelementtype": "^2.2.0"
       }
     },
     "domutils": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
-      "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
       "requires": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
@@ -1806,9 +1756,9 @@
       }
     },
     "entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="
     },
     "env-ci": {
       "version": "5.0.2",
@@ -2771,14 +2721,14 @@
       "dev": true
     },
     "htmlparser2": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.1.2.tgz",
+      "integrity": "sha512-d6cqsbJba2nRdg8WW2okyD4ceonFHn9jLFxhwlNcLhQWcFPdxXeJulgOLjLKtAK9T6ahd+GQNZwG9fjmGW7lyg==",
       "requires": {
         "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
-        "domutils": "^2.5.2",
-        "entities": "^2.0.0"
+        "domhandler": "^4.2.2",
+        "domutils": "^2.8.0",
+        "entities": "^3.0.1"
       }
     },
     "http-cache-semantics": {
@@ -3808,75 +3758,75 @@
       "integrity": "sha512-4zd4txmN7dYEx32kH/K+gecnZhnGDdCrRFK6/n5TGUtqtyjevw0uPul0knJ9PzwDXeNf9MsWzGhjxGeI1M43FA==",
       "dev": true,
       "requires": {
-        "@npmcli/arborist": "*",
-        "@npmcli/ci-detect": "*",
-        "@npmcli/config": "*",
-        "@npmcli/map-workspaces": "*",
-        "@npmcli/package-json": "*",
-        "@npmcli/run-script": "*",
-        "abbrev": "*",
-        "ansicolors": "*",
-        "ansistyles": "*",
-        "archy": "*",
-        "cacache": "*",
-        "chalk": "*",
-        "chownr": "*",
-        "cli-columns": "*",
-        "cli-table3": "*",
-        "columnify": "*",
-        "fastest-levenshtein": "*",
-        "glob": "*",
-        "graceful-fs": "*",
-        "hosted-git-info": "*",
-        "ini": "*",
-        "init-package-json": "*",
-        "is-cidr": "*",
-        "json-parse-even-better-errors": "*",
-        "libnpmaccess": "*",
-        "libnpmdiff": "*",
-        "libnpmexec": "*",
-        "libnpmfund": "*",
-        "libnpmhook": "*",
-        "libnpmorg": "*",
-        "libnpmpack": "*",
-        "libnpmpublish": "*",
-        "libnpmsearch": "*",
-        "libnpmteam": "*",
-        "libnpmversion": "*",
-        "make-fetch-happen": "*",
-        "minipass": "*",
-        "minipass-pipeline": "*",
-        "mkdirp": "*",
-        "mkdirp-infer-owner": "*",
-        "ms": "*",
-        "node-gyp": "*",
-        "nopt": "*",
-        "npm-audit-report": "*",
-        "npm-install-checks": "*",
-        "npm-package-arg": "*",
-        "npm-pick-manifest": "*",
-        "npm-profile": "*",
-        "npm-registry-fetch": "*",
-        "npm-user-validate": "*",
-        "npmlog": "*",
-        "opener": "*",
-        "pacote": "*",
-        "parse-conflict-json": "*",
-        "qrcode-terminal": "*",
-        "read": "*",
-        "read-package-json": "*",
-        "read-package-json-fast": "*",
-        "readdir-scoped-modules": "*",
-        "rimraf": "*",
-        "semver": "*",
-        "ssri": "*",
-        "tar": "*",
-        "text-table": "*",
-        "tiny-relative-date": "*",
-        "treeverse": "*",
-        "validate-npm-package-name": "*",
-        "which": "*",
-        "write-file-atomic": "*"
+        "@npmcli/arborist": "^2.8.3",
+        "@npmcli/ci-detect": "^1.2.0",
+        "@npmcli/config": "^2.3.0",
+        "@npmcli/map-workspaces": "^1.0.4",
+        "@npmcli/package-json": "^1.0.1",
+        "@npmcli/run-script": "^1.8.6",
+        "abbrev": "~1.1.1",
+        "ansicolors": "~0.3.2",
+        "ansistyles": "~0.1.3",
+        "archy": "~1.0.0",
+        "cacache": "^15.3.0",
+        "chalk": "^4.1.2",
+        "chownr": "^2.0.0",
+        "cli-columns": "^3.1.2",
+        "cli-table3": "^0.6.0",
+        "columnify": "~1.5.4",
+        "fastest-levenshtein": "^1.0.12",
+        "glob": "^7.1.7",
+        "graceful-fs": "^4.2.8",
+        "hosted-git-info": "^4.0.2",
+        "ini": "^2.0.0",
+        "init-package-json": "^2.0.5",
+        "is-cidr": "^4.0.2",
+        "json-parse-even-better-errors": "^2.3.1",
+        "libnpmaccess": "^4.0.2",
+        "libnpmdiff": "^2.0.4",
+        "libnpmexec": "^2.0.1",
+        "libnpmfund": "^1.1.0",
+        "libnpmhook": "^6.0.2",
+        "libnpmorg": "^2.0.2",
+        "libnpmpack": "^2.0.1",
+        "libnpmpublish": "^4.0.1",
+        "libnpmsearch": "^3.1.1",
+        "libnpmteam": "^2.0.3",
+        "libnpmversion": "^1.2.1",
+        "make-fetch-happen": "^9.1.0",
+        "minipass": "^3.1.3",
+        "minipass-pipeline": "^1.2.4",
+        "mkdirp": "^1.0.4",
+        "mkdirp-infer-owner": "^2.0.0",
+        "ms": "^2.1.2",
+        "node-gyp": "^7.1.2",
+        "nopt": "^5.0.0",
+        "npm-audit-report": "^2.1.5",
+        "npm-install-checks": "^4.0.0",
+        "npm-package-arg": "^8.1.5",
+        "npm-pick-manifest": "^6.1.1",
+        "npm-profile": "^5.0.3",
+        "npm-registry-fetch": "^11.0.0",
+        "npm-user-validate": "^1.0.1",
+        "npmlog": "^5.0.1",
+        "opener": "^1.5.2",
+        "pacote": "^11.3.5",
+        "parse-conflict-json": "^1.1.1",
+        "qrcode-terminal": "^0.12.0",
+        "read": "~1.0.7",
+        "read-package-json": "^4.1.1",
+        "read-package-json-fast": "^2.0.3",
+        "readdir-scoped-modules": "^1.1.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "ssri": "^8.0.1",
+        "tar": "^6.1.11",
+        "text-table": "~0.2.0",
+        "tiny-relative-date": "^1.3.0",
+        "treeverse": "^1.0.4",
+        "validate-npm-package-name": "~3.0.0",
+        "which": "^2.0.2",
+        "write-file-atomic": "^3.0.3"
       },
       "dependencies": {
         "@gar/promisify": {
@@ -5904,14 +5854,6 @@
         "set-blocking": "~2.0.0"
       }
     },
-    "nth-check": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
-      "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
-      "requires": {
-        "boolbase": "^1.0.0"
-      }
-    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -6066,19 +6008,6 @@
         "error-ex": "^1.3.1",
         "json-parse-even-better-errors": "^2.3.0",
         "lines-and-columns": "^1.1.6"
-      }
-    },
-    "parse5": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
-    },
-    "parse5-htmlparser2-tree-adapter": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
-      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
-      "requires": {
-        "parse5": "^6.0.1"
       }
     },
     "path-exists": {
@@ -7286,11 +7215,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
       "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw=="
-    },
-    "tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
   },
   "dependencies": {
     "chalk": "^4.0.0",
-    "cheerio": "^1.0.0-rc.10",
     "escape-html": "^1.0.3",
     "gaxios": "^4.0.0",
     "glob": "^7.1.6",
+    "htmlparser2": "^7.1.2",
     "jsonexport": "^3.0.0",
     "marked": "^2.0.0",
     "meow": "^9.0.0",
@@ -36,7 +36,6 @@
   },
   "devDependencies": {
     "@types/chai": "^4.2.7",
-    "@types/cheerio": "0.22.30",
     "@types/escape-html": "^1.0.0",
     "@types/glob": "^7.1.3",
     "@types/marked": "^2.0.0",

--- a/src/links.ts
+++ b/src/links.ts
@@ -104,17 +104,6 @@ function isAbsoluteUrl(url: string): boolean {
   return /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(url);
 }
 
-function parseAttr(name: string, value: string): string[] {
-  switch (name) {
-    case 'srcset':
-      return value
-        .split(',')
-        .map((pair: string) => pair.trim().split(/\s+/)[0]);
-    default:
-      return [value];
-  }
-}
-
 function parseLink(link: string, baseUrl: string): ParsedUrl {
   try {
     const url = new URL(link, baseUrl);

--- a/src/links.ts
+++ b/src/links.ts
@@ -1,4 +1,4 @@
-import * as cheerio from 'cheerio';
+import * as htmlParser from 'htmlparser2';
 import {URL} from 'url';
 
 const linksAttr = {
@@ -27,6 +27,14 @@ const linksAttr = {
   ],
   srcset: ['img', 'source'],
 } as {[index: string]: string[]};
+// Create lookup table for tag name to attribute that contains URL:
+const tagAttr: {[index: string]: string[]} = {};
+Object.keys(linksAttr).forEach(attr => {
+  for (const tag of linksAttr[attr]) {
+    if (!tagAttr[tag]) tagAttr[tag] = [];
+    tagAttr[tag].push(attr);
+  }
+});
 
 export interface ParsedUrl {
   link: string;
@@ -35,51 +43,44 @@ export interface ParsedUrl {
 }
 
 export function getLinks(source: string, baseUrl: string): ParsedUrl[] {
-  const $ = cheerio.load(source);
   let realBaseUrl = baseUrl;
-  const base = $('base[href]');
-  if (base.length) {
-    // only first <base by specification
-    const htmlBaseUrl = base.first().attr('href')!;
-    realBaseUrl = getBaseUrl(htmlBaseUrl, baseUrl);
-  }
+  let baseSet = false;
   const links = new Array<ParsedUrl>();
-  const attrs = Object.keys(linksAttr);
-  for (const attr of attrs) {
-    const elements = linksAttr[attr].map(tag => `${tag}[${attr}]`).join(',');
-    $(elements).each((i, ele) => {
-      const element = ele as cheerio.TagElement;
-      if (!element.attribs) {
-        return;
+  const parser = new htmlParser.Parser({
+    onopentag(tag: string, attributes: {[s: string]: string}) {
+      // Allow alternate base URL to be specified in tag:
+      if (tag === 'base' && !baseSet) {
+        realBaseUrl = getBaseUrl(attributes.href, baseUrl);
+        baseSet = true;
       }
-      const values = parseAttr(attr, element.attribs[attr]);
+
       // ignore href properties for link tags where rel is likely to fail
       const relValuesToIgnore = ['dns-prefetch', 'preconnect'];
-      if (
-        element.tagName === 'link' &&
-        relValuesToIgnore.includes(element.attribs['rel'])
-      ) {
+      if (tag === 'link' && relValuesToIgnore.includes(attributes.rel)) {
         return;
       }
 
       // Only for <meta content=""> tags, only validate the url if
       // the content actually looks like a url
-      if (element.tagName === 'meta' && element.attribs['content']) {
+      if (tag === 'meta' && attributes.content) {
         try {
-          new URL(element.attribs['content']);
+          new URL(attributes.content);
         } catch (e) {
           return;
         }
       }
 
-      for (const v of values) {
-        if (v) {
-          const link = parseLink(v, realBaseUrl);
-          links.push(link);
+      if (tagAttr[tag]) {
+        for (const attr of tagAttr[tag]) {
+          if (attributes[attr]) {
+            links.push(parseLink(attributes[attr], realBaseUrl));
+          }
         }
       }
-    });
-  }
+    },
+  });
+  parser.write(source);
+  parser.end();
   return links;
 }
 


### PR DESCRIPTION
Refactor to use htmlparser2 which performs parsing in a single pass. _This is the same underlying parser used by cheerio._

## Why?

This significantly increases the performance of parsing, here are the before and after timings for `nodejs-ai-platform` (_one of our repositories with the largest number of links:_)

**before:**

🤖 Successfully scanned 2166 links in 1267.81 seconds.

**after:**

🤖 Successfully scanned 2166 links in 407.295 seconds.