### PR TITLE
build: enable a few more ESLint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,6 +8,7 @@
         "allowElseIf": false
       }
     ],
+    "no-implicit-coercion": "error",
     "no-lonely-if": "error",
     "no-promise-executor-return": "error",
     "no-undef-init": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,38 @@
 {
-  "extends": "./node_modules/gts"
+  "extends": "./node_modules/gts",
+  "rules": {
+    "dot-notation": "off",
+    "no-else-return": [
+      "error",
+      {
+        "allowElseIf": false
+      }
+    ],
+    "no-lonely-if": "error",
+    "no-promise-executor-return": "error",
+    "no-undef-init": "error",
+    "no-useless-return": "error",
+    "prefer-object-spread": "error",
+    "prefer-spread": "error"
+  },
+  "overrides": [
+    {
+      "files": [
+        "**/*.ts",
+        "**/*.tsx"
+      ],
+      "parser": "@typescript-eslint/parser",
+      "parserOptions": {
+        "project": "./tsconfig.json"
+      },
+      "rules": {
+        "@typescript-eslint/dot-notation": "error",
+        "@typescript-eslint/no-unnecessary-type-assertion": "error",
+        "@typescript-eslint/prefer-for-of": "error",
+        "@typescript-eslint/prefer-includes": "error",
+        "@typescript-eslint/prefer-readonly": "error",
+        "@typescript-eslint/promise-function-async": "error"
+      }
+    }
+  ]
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -197,77 +197,77 @@ async function main() {
     result.links = filteredResults;
     console.log(JSON.stringify(result, null, 2));
     return;
-  } else if (format === Format.CSV) {
+  }
+  if (format === Format.CSV) {
     result.links = filteredResults;
     const csv = await toCSV(result.links);
     console.log(csv);
     return;
-  } else {
-    // Build a collection scanned links, collated by the parent link used in
-    // the scan.  For example:
-    // {
-    //   "./README.md": [
-    //     {
-    //       url: "https://img.shields.io/npm/v/linkinator.svg",
-    //       status: 200
-    //       ....
-    //     }
-    //   ],
-    // }
-    const parents = result.links.reduce((acc, curr) => {
-      const parent = curr.parent || '';
-      if (!acc[parent]) {
-        acc[parent] = [];
-      }
-      acc[parent].push(curr);
-      return acc;
-    }, {} as {[index: string]: LinkResult[]});
+  }
+  // Build a collection scanned links, collated by the parent link used in
+  // the scan.  For example:
+  // {
+  //   "./README.md": [
+  //     {
+  //       url: "https://img.shields.io/npm/v/linkinator.svg",
+  //       status: 200
+  //       ....
+  //     }
+  //   ],
+  // }
+  const parents = result.links.reduce((acc, curr) => {
+    const parent = curr.parent || '';
+    if (!acc[parent]) {
+      acc[parent] = [];
+    }
+    acc[parent].push(curr);
+    return acc;
+  }, {} as {[index: string]: LinkResult[]});
 
-    Object.keys(parents).forEach(parent => {
-      // prune links based on verbosity
-      const links = parents[parent].filter(link => {
-        if (verbosity === LogLevel.NONE) {
-          return false;
-        }
-        if (link.state === LinkState.BROKEN) {
+  Object.keys(parents).forEach(parent => {
+    // prune links based on verbosity
+    const links = parents[parent].filter(link => {
+      if (verbosity === LogLevel.NONE) {
+        return false;
+      }
+      if (link.state === LinkState.BROKEN) {
+        return true;
+      }
+      if (link.state === LinkState.OK) {
+        if (verbosity <= LogLevel.WARNING) {
           return true;
         }
-        if (link.state === LinkState.OK) {
-          if (verbosity <= LogLevel.WARNING) {
-            return true;
-          }
-        }
-        if (link.state === LinkState.SKIPPED) {
-          if (verbosity <= LogLevel.INFO) {
-            return true;
-          }
-        }
-        return false;
-      });
-      if (links.length === 0) {
-        return;
       }
-      logger.error(chalk.blue(parent));
-      links.forEach(link => {
-        let state = '';
-        switch (link.state) {
-          case LinkState.BROKEN:
-            state = `[${chalk.red(link.status!.toString())}]`;
-            logger.error(`  ${state} ${chalk.gray(link.url)}`);
-            logger.debug(JSON.stringify(link.failureDetails, null, 2));
-            break;
-          case LinkState.OK:
-            state = `[${chalk.green(link.status!.toString())}]`;
-            logger.warn(`  ${state} ${chalk.gray(link.url)}`);
-            break;
-          case LinkState.SKIPPED:
-            state = `[${chalk.grey('SKP')}]`;
-            logger.info(`  ${state} ${chalk.gray(link.url)}`);
-            break;
+      if (link.state === LinkState.SKIPPED) {
+        if (verbosity <= LogLevel.INFO) {
+          return true;
         }
-      });
+      }
+      return false;
     });
-  }
+    if (links.length === 0) {
+      return;
+    }
+    logger.error(chalk.blue(parent));
+    links.forEach(link => {
+      let state = '';
+      switch (link.state) {
+        case LinkState.BROKEN:
+          state = `[${chalk.red(link.status!.toString())}]`;
+          logger.error(`  ${state} ${chalk.gray(link.url)}`);
+          logger.debug(JSON.stringify(link.failureDetails, null, 2));
+          break;
+        case LinkState.OK:
+          state = `[${chalk.green(link.status!.toString())}]`;
+          logger.warn(`  ${state} ${chalk.gray(link.url)}`);
+          break;
+        case LinkState.SKIPPED:
+          state = `[${chalk.grey('SKP')}]`;
+          logger.info(`  ${state} ${chalk.gray(link.url)}`);
+          break;
+      }
+    });
+  });
 
   const total = (Date.now() - start) / 1000;
   const scannedLinks = result.links.filter(x => x.state !== LinkState.SKIPPED);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -166,7 +166,7 @@ async function main() {
   };
   if (flags.skip) {
     if (typeof flags.skip === 'string') {
-      opts.linksToSkip = flags.skip.split(/[\s,]+/).filter(x => !!x);
+      opts.linksToSkip = flags.skip.split(/[\s,]+/).filter(x => Boolean(x));
     } else if (Array.isArray(flags.skip)) {
       opts.linksToSkip = flags.skip;
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,7 +40,7 @@ export async function getConfig(flags: Flags) {
   // `meow` is set up to pass boolean flags as `undefined` if not passed.
   // copy the struct, and delete properties that are `undefined` so the merge
   // doesn't blast away config level settings.
-  const strippedFlags = Object.assign({}, flags);
+  const strippedFlags = {...flags};
   Object.entries(strippedFlags).forEach(([key, value]) => {
     if (typeof value === 'undefined') {
       delete (strippedFlags as {[index: string]: {}})[key];
@@ -49,6 +49,6 @@ export async function getConfig(flags: Flags) {
 
   // combine the flags passed on the CLI with the flags in the config file,
   // with CLI flags getting precedence
-  config = Object.assign({}, config, strippedFlags);
+  config = {...config, ...strippedFlags};
   return config;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -229,7 +229,7 @@ export class LinkChecker extends EventEmitter {
     let status = 0;
     let state = LinkState.BROKEN;
     let shouldRecurse = false;
-    let res: GaxiosResponse<Readable> | undefined = undefined;
+    let res: GaxiosResponse<Readable> | undefined;
     const failures: {}[] = [];
     try {
       res = await request<Readable>({
@@ -331,14 +331,15 @@ export class LinkChecker extends EventEmitter {
           continue;
         }
 
-        let crawl = (opts.checkOptions.recurse! &&
-          result.url?.href.startsWith(opts.rootPath)) as boolean;
+        let crawl =
+          opts.checkOptions.recurse! &&
+          result.url?.href.startsWith(opts.rootPath);
 
         // only crawl links that start with the same host
         if (crawl) {
           try {
             const pathUrl = new URL(opts.rootPath);
-            crawl = result.url!.host === pathUrl.host;
+            crawl = result.url.host === pathUrl.host;
           } catch {
             // ignore errors
           }
@@ -475,5 +476,5 @@ function mapUrl(url?: string, options?: InternalCheckOptions): string {
       newUrl = `.${path.sep}`;
     }
   }
-  return newUrl!;
+  return newUrl;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,7 @@ export class LinkChecker extends EventEmitter {
           delayCache,
           queue,
           rootPath: path,
-          retry: !!opts.retry,
+          retry: Boolean(opts.retry),
         });
       });
     }
@@ -195,7 +195,7 @@ export class LinkChecker extends EventEmitter {
         .map(linkToSkip => {
           return new RegExp(linkToSkip).test(opts.url.href);
         })
-        .filter(match => !!match);
+        .filter(match => Boolean(match));
 
       if (skips.length > 0) {
         const result: LinkResult = {
@@ -442,8 +442,8 @@ export async function check(options: CheckOptions) {
 function isHtml(response: GaxiosResponse): boolean {
   const contentType = response.headers['content-type'] || '';
   return (
-    !!contentType.match(/text\/html/g) ||
-    !!contentType.match(/application\/xhtml\+xml/g)
+    Boolean(contentType.match(/text\/html/g)) ||
+    Boolean(contentType.match(/application\/xhtml\+xml/g))
   );
 }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -37,7 +37,7 @@ export interface InternalCheckOptions extends CheckOptions {
 export async function processOptions(
   opts: CheckOptions
 ): Promise<InternalCheckOptions> {
-  const options = Object.assign({}, opts) as InternalCheckOptions;
+  const options = {...opts} as InternalCheckOptions;
 
   // ensure at least one path is provided
   if (options.path.length === 0) {
@@ -56,7 +56,7 @@ export async function processOptions(
 
   // Ensure we do not mix http:// and file system paths.  The paths passed in
   // must all be filesystem paths, or HTTP paths.
-  let isUrlType: boolean | undefined = undefined;
+  let isUrlType: boolean | undefined;
   for (const path of options.path) {
     const innerIsUrlType = path.startsWith('http');
     if (isUrlType === undefined) {
@@ -136,8 +136,7 @@ export async function processOptions(
       if (s.isFile()) {
         const pathParts = options.path[0].split(path.sep);
         options.path = [path.join('.', pathParts[pathParts.length - 1])];
-        options.serverRoot =
-          pathParts.slice(0, pathParts.length - 1).join(path.sep) || '.';
+        options.serverRoot = pathParts.slice(0, -1).join(path.sep) || '.';
       } else {
         options.serverRoot = options.path[0];
         options.path = '/';

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -20,9 +20,9 @@ export declare interface Queue {
 export type AsyncFunction = () => Promise<void>;
 
 export class Queue extends EventEmitter {
-  private q: Array<QueueItem> = [];
+  private readonly q: Array<QueueItem> = [];
   private activeFunctions = 0;
-  private concurrency: number;
+  private readonly concurrency: number;
 
   constructor(options: QueueOptions) {
     super();
@@ -46,6 +46,7 @@ export class Queue extends EventEmitter {
       return;
     }
 
+    // eslint-disable-next-line @typescript-eslint/prefer-for-of
     for (let i = 0; i < this.q.length; i++) {
       // Check if we have too many concurrent functions executing
       if (this.activeFunctions >= this.concurrency) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -33,7 +33,7 @@ export async function startWebServer(options: WebServerOptions) {
   const root = path.resolve(options.root);
   return new Promise<http.Server>((resolve, reject) => {
     const server = http
-      .createServer((req, res) => handleRequest(req, res, root, options))
+      .createServer(async (req, res) => handleRequest(req, res, root, options))
       .listen(options.port || 0, () => resolve(server))
       .on('error', reject);
     if (!options.port) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -51,7 +51,7 @@ async function handleRequest(
   options: WebServerOptions
 ) {
   const url = new URL(req.url || '/', `http://localhost:${options.port}`);
-  const pathParts = url.pathname.split('/').filter(x => !!x);
+  const pathParts = url.pathname.split('/').filter(x => Boolean(x));
   const originalPath = path.join(root, ...pathParts);
   if (url.pathname.endsWith('/')) {
     pathParts.push('index.html');

--- a/test/test.cli.ts
+++ b/test/test.cli.ts
@@ -258,7 +258,9 @@ describe('cli', function () {
       res.end();
     });
     enableDestroy(server);
-    await new Promise<void>(r => server.listen(port, r));
+    await new Promise<void>(r => {
+      server.listen(port, r);
+    });
 
     const res = await execa(node, [
       linkinator,

--- a/test/test.index.ts
+++ b/test/test.index.ts
@@ -59,7 +59,7 @@ describe('linkinator', () => {
     const scope = nock('https://good.com').head('/').reply(200);
     const results = await check({
       path: 'test/fixtures/filter',
-      linksToSkip: link => Promise.resolve(link.includes('filterme')),
+      linksToSkip: async link => Promise.resolve(link.includes('filterme')),
     });
     assert.ok(results.passed);
     assert.strictEqual(
@@ -134,8 +134,7 @@ describe('linkinator', () => {
       },
     ];
 
-    for (let i = 0; i < cases.length; i++) {
-      const {fixture, nonBrokenUrl} = cases[i];
+    for (const {fixture, nonBrokenUrl} of cases) {
       const scope = nock('http://fake.local')
         .get('/pageBase/index')
         .replyWithFile(200, fixture, {


### PR DESCRIPTION
This is my second take after #244.

The non-whitespace diff is easier to view: https://github.com/JustinBeckwith/linkinator/pull/339/files?w=1

IIRC we discussed these rules in #244 @JustinBeckwith.

If you want me to make a change let me know :)

PS1. the test failures seem weird, everything's green locally :/
PS2. I would also enable `array-callback-return` since it's easy to miss some cases, but I'll leave it to you :)
