### PR TITLE
fix: special handling of srcset attribute

### DIFF
--- a/src/links.ts
+++ b/src/links.ts
@@ -76,8 +76,11 @@ export async function getLinks(
 
       if (tagAttr[tag]) {
         for (const attr of tagAttr[tag]) {
-          if (attributes[attr]) {
-            links.push(parseLink(attributes[attr], realBaseUrl));
+          const linkStr = attributes[attr];
+          if (linkStr) {
+            for (const link of parseAttr(attr, linkStr)) {
+              links.push(parseLink(link, realBaseUrl));
+            }
           }
         }
       }
@@ -107,6 +110,17 @@ function isAbsoluteUrl(url: string): boolean {
   // Scheme: https://tools.ietf.org/html/rfc3986#section-3.1
   // Absolute URL: https://tools.ietf.org/html/rfc3986#section-4.3
   return /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(url);
+}
+
+function parseAttr(name: string, value: string): string[] {
+  switch (name) {
+    case 'srcset':
+      return value
+        .split(',')
+        .map((pair: string) => pair.trim().split(/\s+/)[0]);
+    default:
+      return [value];
+  }
 }
 
 function parseLink(link: string, baseUrl: string): ParsedUrl {

--- a/test/fixtures/srcset/_site/bar.html
+++ b/test/fixtures/srcset/_site/bar.html
@@ -1,0 +1,4 @@
+<html>
+<body>
+</body>
+</html>

--- a/test/fixtures/srcset/_site/foo.html
+++ b/test/fixtures/srcset/_site/foo.html
@@ -1,0 +1,4 @@
+<html>
+<body>
+</body>
+</html>

--- a/test/fixtures/srcset/index.html
+++ b/test/fixtures/srcset/index.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-<img srcset="_site/foo.html@batman, _site/bar.html">comma separated list of URLs</a>
+<img srcset="_site/foo.html, _site/bar.html">comma separated list of URLs</a>
 </body>
 </html>

--- a/test/fixtures/srcset/index.html
+++ b/test/fixtures/srcset/index.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-<img srcset="_site/foo.html, _site/bar.html">comma separated list of URLs</a>
+<img srcset="_site/foo.html, _site/bar.html"></img>
 </body>
 </html>

--- a/test/fixtures/srcset/index.html
+++ b/test/fixtures/srcset/index.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<img srcset="_site/foo.html@batman, _site/bar.html">comma separated list of URLs</a>
+</body>
+</html>

--- a/test/test.index.ts
+++ b/test/test.index.ts
@@ -537,4 +537,18 @@ describe('linkinator', () => {
     });
     assert.ok(results.passed);
   });
+
+  it('should report malformed links as broken', async () => {
+    const results = await check({path: 'test/fixtures/malformed'});
+    assert.ok(!results.passed);
+    assert.strictEqual(
+      results.links.filter(x => x.state === LinkState.BROKEN).length,
+      1
+    );
+  });
+
+  it('should handle comma separated srcset', async () => {
+    const results = await check({path: 'test/fixtures/srcset'});
+    assert.ok(results.passed);
+  });
 });


### PR DESCRIPTION
Handling of `srcset` attribute was broken in migration to new parser.

Fixes #337