### PR TITLE
tests: try to fix the timeout errors

### DIFF
--- a/test/test.retry.ts
+++ b/test/test.retry.ts
@@ -104,7 +104,8 @@ describe('retries', () => {
     scope.done();
   });
 
-  it('should detect requests to wait on the same host', async () => {
+  it('should detect requests to wait on the same host', async function () {
+    this.timeout(10_000);
     const scope = nock('http://fake.local')
       .get('/1')
       .reply(429, undefined, {


### PR DESCRIPTION
It seems there's one more place tests time out. Should I move the timeout to the describe block so that we cover more cases?