### PR TITLE
feat: exponential backoff

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -112,7 +112,7 @@ const cli = meow(
       directoryListing: {type: 'boolean'},
       retry: {type: 'boolean'},
       retryErrors: {type: 'boolean'},
-      retryErrorsCount: {type: 'number', default: 3},
+      retryErrorsCount: {type: 'number', default: 5},
       retryErrorsJitter: {type: 'number', default: 3000},
       urlRewriteSearch: {type: 'string'},
       urlReWriteReplace: {type: 'string'},


### PR DESCRIPTION
* Adds an exponential backoff rather than just a random delay, which I think is more likely to avoid errors.
* Increases default retries to 5, so that the default maximum retry delay will be 30s (starting at 2s).
* Adds test that retries terminate.
* Partially address painful bug I bumped into trying to write tests.