### PR TITLE
fix: retry on href not host

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -456,15 +456,15 @@ export class LinkChecker extends EventEmitter {
       return false;
     }
 
-    // check to see if there is already a request to wait for this host
+    // check to see if there is already a request to wait for this URL:
     let currentRetries = 1;
-    if (opts.retryErrorsCache.has(opts.url.host)) {
+    if (opts.retryErrorsCache.has(opts.url.href)) {
       // use whichever time is higher in the cache
-      currentRetries = opts.retryErrorsCache.get(opts.url.host)!;
+      currentRetries = opts.retryErrorsCache.get(opts.url.href)!;
       if (currentRetries > maxRetries) return false;
-      opts.retryErrorsCache.set(opts.url.host, currentRetries + 1);
+      opts.retryErrorsCache.set(opts.url.href, currentRetries + 1);
     } else {
-      opts.retryErrorsCache.set(opts.url.host, 1);
+      opts.retryErrorsCache.set(opts.url.href, 1);
     }
     // Use exponential backoff algorithm to take pressure off upstream service:
     const retryAfter =


### PR DESCRIPTION
Managed to reproduce `[0]` crawl issue locally using the following test repository:

https://github.com/bcoe/external-link-repo

Designed specifcially to trigger the bug.

----

tldr; there was a slight bug with the retry logic, rather than retrying failed links, it was only caching one entry per host. This meant that when a burst of errors occurred, we would immediately hit the stop condition and not actually retry the failed URLs.

I have not been able to recreate the failure when running locally with this fix.

