### PR TITLE
build: disable binary builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,8 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run compile
-      - run: npm run build-binaries
+# disabed due to https://github.com/vercel/pkg/issues/1291
+#     - run: npm run build-binaries
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Due to https://github.com/vercel/pkg/issues/1291, the build is current broken.  This disables those builds until the underlying issue can be fixed. 