### PR TITLE
fix!: stream CSV results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "gaxios": "^5.0.0",
         "glob": "^8.0.1",
         "htmlparser2": "^8.0.1",
-        "jsonexport": "^3.2.0",
         "marked": "^4.0.3",
         "meow": "^10.1.1",
         "mime": "^3.0.0",
@@ -25,10 +24,8 @@
         "linkinator": "build/src/cli.js"
       },
       "devDependencies": {
-        "@types/chai": "^4.2.22",
         "@types/escape-html": "^1.0.1",
         "@types/glob": "^7.2.0",
-        "@types/jsonexport": "^3.0.2",
         "@types/marked": "^4.0.0",
         "@types/mime": "^2.0.3",
         "@types/mocha": "^9.0.0",
@@ -37,7 +34,6 @@
         "@types/sinon": "^10.0.6",
         "@types/update-notifier": "^6.0.0",
         "c8": "^7.10.0",
-        "chai": "^4.3.4",
         "codecov": "^3.8.2",
         "execa": "^6.0.0",
         "gts": "^4.0.0",
@@ -717,12 +713,6 @@
         "@types/responselike": "*"
       }
     },
-    "node_modules/@types/chai": {
-      "version": "4.2.22",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.22.tgz",
-      "integrity": "sha512-tFfcE+DSTzWAgifkjik9AySNqIyNoYwmR+uecPwwD/XRNfvOjmC/FjCxpiUGDkDVDphPfCUecSQVFw+lN3M3kQ==",
-      "dev": true
-    },
     "node_modules/@types/configstore": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@types/configstore/-/configstore-5.0.1.tgz",
@@ -766,15 +756,6 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
-    },
-    "node_modules/@types/jsonexport": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/jsonexport/-/jsonexport-3.0.2.tgz",
-      "integrity": "sha512-VrWj30OihopTEE7jDiXO1IbrCF+iNiKi9eLtz03RsazWQCyp1rsMlap1W0V1xjT6ULiilKZP4qXYoWFADnMn8A==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
@@ -1282,15 +1263,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -1716,23 +1688,6 @@
         "cdl": "bin/cdl.js"
       }
     },
-    "node_modules/chai": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
-      "dev": true,
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
-        "get-func-name": "^2.0.0",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.5"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/chalk": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
@@ -1749,15 +1704,6 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
-    },
-    "node_modules/check-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/chokidar": {
       "version": "3.5.3",
@@ -2320,18 +2266,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-      "dev": true,
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=0.12"
       }
     },
     "node_modules/deep-extend": {
@@ -3609,15 +3543,6 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -4644,14 +4569,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jsonexport": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonexport/-/jsonexport-3.2.0.tgz",
-      "integrity": "sha512-GbO9ugb0YTZatPd/hqCGR0FSwbr82H6OzG04yzdrG7XOe4QZ0jhQ+kOsB29zqkzoYJLmLxbbrFiuwbQu891XnQ==",
-      "bin": {
-        "jsonexport": "bin/jsonexport.js"
       }
     },
     "node_modules/jsonfile": {
@@ -8520,15 +8437,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -11117,12 +11025,6 @@
         "@types/responselike": "*"
       }
     },
-    "@types/chai": {
-      "version": "4.2.22",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.22.tgz",
-      "integrity": "sha512-tFfcE+DSTzWAgifkjik9AySNqIyNoYwmR+uecPwwD/XRNfvOjmC/FjCxpiUGDkDVDphPfCUecSQVFw+lN3M3kQ==",
-      "dev": true
-    },
     "@types/configstore": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@types/configstore/-/configstore-5.0.1.tgz",
@@ -11166,15 +11068,6 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
-    },
-    "@types/jsonexport": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/jsonexport/-/jsonexport-3.0.2.tgz",
-      "integrity": "sha512-VrWj30OihopTEE7jDiXO1IbrCF+iNiKi9eLtz03RsazWQCyp1rsMlap1W0V1xjT6ULiilKZP4qXYoWFADnMn8A==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/keyv": {
       "version": "3.1.4",
@@ -11538,12 +11431,6 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
-    "assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true
-    },
     "at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -11829,20 +11716,6 @@
         "redeyed": "~2.1.0"
       }
     },
-    "chai": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
-      "dev": true,
-      "requires": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
-        "get-func-name": "^2.0.0",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.5"
-      }
-    },
     "chalk": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
@@ -11852,12 +11725,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true
-    },
-    "check-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "chokidar": {
@@ -12284,15 +12151,6 @@
           "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
           "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
         }
-      }
-    },
-    "deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-      "dev": true,
-      "requires": {
-        "type-detect": "^4.0.0"
       }
     },
     "deep-extend": {
@@ -13225,12 +13083,6 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
-    "get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
-      "dev": true
-    },
     "get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -13984,11 +13836,6 @@
       "requires": {
         "minimist": "^1.2.5"
       }
-    },
-    "jsonexport": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonexport/-/jsonexport-3.2.0.tgz",
-      "integrity": "sha512-GbO9ugb0YTZatPd/hqCGR0FSwbr82H6OzG04yzdrG7XOe4QZ0jhQ+kOsB29zqkzoYJLmLxbbrFiuwbQu891XnQ=="
     },
     "jsonfile": {
       "version": "6.1.0",
@@ -16711,12 +16558,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true
-    },
-    "pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true
     },
     "picomatch": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "gaxios": "^5.0.0",
     "glob": "^8.0.1",
     "htmlparser2": "^8.0.1",
-    "jsonexport": "^3.2.0",
     "marked": "^4.0.3",
     "meow": "^10.1.1",
     "mime": "^3.0.0",
@@ -36,10 +35,8 @@
     "update-notifier": "^6.0.0"
   },
   "devDependencies": {
-    "@types/chai": "^4.2.22",
     "@types/escape-html": "^1.0.1",
     "@types/glob": "^7.2.0",
-    "@types/jsonexport": "^3.0.2",
     "@types/marked": "^4.0.0",
     "@types/mime": "^2.0.3",
     "@types/mocha": "^9.0.0",
@@ -48,7 +45,6 @@
     "@types/sinon": "^10.0.6",
     "@types/update-notifier": "^6.0.0",
     "c8": "^7.10.0",
-    "chai": "^4.3.4",
     "codecov": "^3.8.2",
     "execa": "^6.0.0",
     "gts": "^4.0.0",

--- a/test/test.cli.ts
+++ b/test/test.cli.ts
@@ -1,6 +1,6 @@
 import {describe, it} from 'mocha';
 import {execa} from 'execa';
-import {assert} from 'chai';
+import assert from 'assert';
 import http from 'http';
 import util from 'util';
 import {URL} from 'url';
@@ -98,7 +98,7 @@ describe('cli', function () {
       'csv',
       'test/fixtures/markdown/README.md',
     ]);
-    assert.match(res.stdout, /README.md,200,OK,/);
+    assert.match(res.stdout, /README.md",200,OK,/);
   });
 
   it('should provide JSON if asked nicely', async () => {
@@ -118,7 +118,7 @@ describe('cli', function () {
       '--silent',
       'test/fixtures/markdown/README.md',
     ]);
-    assert.notMatch(res.stdout, /\[/);
+    assert.doesNotMatch(res.stdout, /\[/);
   });
 
   it('should not show 200 links if verbosity is ERROR with JSON', async () => {
@@ -274,7 +274,7 @@ describe('cli', function () {
         requestCount++;
         firstRequestTime = Date.now();
       } else {
-        assert.isAtLeast(Date.now(), firstRequestTime + delayMillis);
+        assert.ok(Date.now() >= firstRequestTime + delayMillis);
         res.writeHead(200);
       }
       res.end();
@@ -288,6 +288,6 @@ describe('cli', function () {
       'test/fixtures/retryCLI',
     ]);
     assert.strictEqual(res.exitCode, 0);
-    assert.include(res.stdout, `Retrying: http://localhost:${port}`);
+    assert.match(res.stdout, new RegExp(`Retrying: http://localhost:${port}/`));
   });
 });

--- a/test/test.retry.ts
+++ b/test/test.retry.ts
@@ -1,4 +1,4 @@
-import {assert} from 'chai';
+import assert from 'assert';
 import nock from 'nock';
 import sinon from 'sinon';
 import {describe, it, afterEach} from 'mocha';
@@ -111,12 +111,12 @@ describe('retries', () => {
         'retry-after': '3',
       })
       .get('/1', () => {
-        assert.isAtLeast(Date.now(), 3000);
+        assert.ok(Date.now() >= 3000);
         return true;
       })
       .reply(200)
       .get('/2', () => {
-        assert.isAtLeast(Date.now(), 3000);
+        assert.ok(Date.now() >= 3000);
         return true;
       })
       .reply(200)
@@ -125,7 +125,7 @@ describe('retries', () => {
         'retry-after': '3',
       })
       .get('/3', () => {
-        assert.isAtLeast(Date.now(), 3000);
+        assert.ok(Date.now() >= 3000);
         return true;
       })
       .reply(200);
@@ -158,12 +158,12 @@ describe('retries', () => {
         // make sure the /3 route reset it to 9 seconds here. This is common
         // when a flood of requests come through and the retry-after gets
         // extended.
-        assert.isAtLeast(Date.now(), 9000);
+        assert.ok(Date.now() >= 9000);
         return true;
       })
       .reply(200)
       .get('/2', () => {
-        assert.isAtLeast(Date.now(), 9000);
+        assert.ok(Date.now() >= 9000);
         return true;
       })
       .reply(200)
@@ -172,7 +172,7 @@ describe('retries', () => {
         'retry-after': '9',
       })
       .get('/3', () => {
-        assert.isAtLeast(Date.now(), 9000);
+        assert.ok(Date.now() >= 9000);
         return true;
       })
       .reply(200);


### PR DESCRIPTION
Fixes #498.  Instead of building up all CSV results until the end, the CLI will now stream the results as they come in.  This does mean moving from [jsonexport](https://www.npmjs.com/package/jsonexport) to a custom CSV generator, which could in theory be a breaking change for someone.   