### PR TITLE
fix: address srcset parsing with multiple spaces

### DIFF
--- a/src/links.ts
+++ b/src/links.ts
@@ -115,8 +115,13 @@ function isAbsoluteUrl(url: string): boolean {
 
 function parseAttr(name: string, value: string): string[] {
   switch (name) {
-    case 'srcset':
-      return parseSrcset(value).map(p => p.url);
+    case 'srcset': {
+      // The swapping of any multiple spaces into a single space is here to
+      // work around this bug:
+      // https://github.com/sindresorhus/srcset/issues/14
+      const strippedValue = value.replace(/\s+/, ' ');
+      return parseSrcset(strippedValue).map(p => p.url);
+    }
     default:
       return [value];
   }

--- a/test/fixtures/srcset/index.html
+++ b/test/fixtures/srcset/index.html
@@ -1,5 +1,6 @@
 <html>
 <body>
 <img srcset="_site/foo.html, _site/bar.html"></img>
+<img srcset="_site/foo.html,                 _site/bar.html"></img>
 </body>
 </html>


### PR DESCRIPTION
Fixes #511.  This is a hack to paper over a bug in the npm module srcset:
https://github.com/sindresorhus/srcset/issues/14