### PR TITLE
feat(Config): Support for Javascript based config files

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,10 @@ export async function getConfig(flags: Flags) {
   if (flags.config) {
     config = await parseConfigFile(configPath);
   }
+
+  // `meow` is set up to pass boolean flags as `undefined` if not passed.
+  // copy the struct, and delete properties that are `undefined` so the merge
+  // doesn't blast away config level settings.
   const strippedFlags = Object.assign({}, flags);
   Object.entries(strippedFlags).forEach(([key, value]) => {
     if (
@@ -86,7 +90,7 @@ async function importConfigFile(configPath: string): Promise<Flags> {
 }
 
 async function readJsonConfigFile(configPath: string): Promise<Flags> {
-  const configFileContents: string = await fs.readFile(configPath, {
+  const configFileContents = await fs.readFile(configPath, {
     encoding: 'utf-8',
   });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -83,8 +83,7 @@ function getTypeOfConfig(configPath: string): ConfigExtensions {
 }
 
 async function importConfigFile(configPath: string): Promise<Flags> {
-  const config = (await import(path.resolve(process.cwd(), configPath)))
-    .default;
+  const config = (await import(path.join(process.cwd(), configPath))).default;
 
   return config;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -83,7 +83,8 @@ function getTypeOfConfig(configPath: string): ConfigExtensions {
 }
 
 async function importConfigFile(configPath: string): Promise<Flags> {
-  const config = (await import(path.join(process.cwd(), configPath))).default;
+  const config = (await import(path.resolve(process.cwd(), configPath)))
+    .default;
 
   return config;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -86,13 +86,9 @@ async function importConfigFile(configPath: string): Promise<Flags> {
 }
 
 async function readJsonConfigFile(configPath: string): Promise<Flags> {
-  try {
-    const configFileContents: string = await fs.readFile(configPath, {
-      encoding: 'utf-8',
-    });
-    return JSON.parse(configFileContents);
-  } catch (e) {
-    console.error(`Unable to read or parse the JSON config file ${configPath}`);
-    throw e;
-  }
+  const configFileContents: string = await fs.readFile(configPath, {
+    encoding: 'utf-8',
+  });
+
+  return JSON.parse(configFileContents);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,18 +45,18 @@ export async function getConfig(flags: Flags) {
   return config;
 }
 
-const validConfigExtensions = ['js', 'mjs', 'cjs', 'json'];
+const validConfigExtensions = ['.js', '.mjs', '.cjs', '.json'];
 type ConfigExtensions = typeof validConfigExtensions[number];
 
 async function parseConfigFile(configPath: string): Promise<Flags> {
   const typeOfConfig = getTypeOfConfig(configPath);
 
   switch (typeOfConfig) {
-    case 'json':
+    case '.json':
       return readJsonConfigFile(configPath);
-    case 'js':
-    case 'mjs':
-    case 'cjs':
+    case '.js':
+    case '.mjs':
+    case '.cjs':
       return importConfigFile(configPath);
   }
 
@@ -64,24 +64,24 @@ async function parseConfigFile(configPath: string): Promise<Flags> {
 }
 
 function getTypeOfConfig(configPath: string): ConfigExtensions {
-  const lastDotIndex = configPath.lastIndexOf('.');
-
   // Returning json in case file doesn't have an extension for backward compatibility
-  if (lastDotIndex === -1) return 'json';
+  const configExtension = path.extname(configPath) || '.json';
 
-  const configFileExtension: string = configPath.slice(lastDotIndex + 1);
-
-  if (validConfigExtensions.includes(configFileExtension)) {
-    return configFileExtension as ConfigExtensions;
+  if (validConfigExtensions.includes(configExtension)) {
+    return configExtension as ConfigExtensions;
   }
 
   throw new Error(
-    `Config file should be either of ${validConfigExtensions.join(',')}`
+    `Config file should be either of extensions ${validConfigExtensions.join(
+      ','
+    )}`
   );
 }
 
 async function importConfigFile(configPath: string): Promise<Flags> {
-  const config = (await import(path.join(process.cwd(), configPath))).default;
+  const config = (await import(path.resolve(process.cwd(), configPath)))
+    .default;
+
   return config;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -83,8 +83,9 @@ function getTypeOfConfig(configPath: string): ConfigExtensions {
 }
 
 async function importConfigFile(configPath: string): Promise<Flags> {
-  const config = (await import(path.resolve(process.cwd(), configPath)))
-    .default;
+  const config = (
+    await import(`file://${path.resolve(process.cwd(), configPath)}`)
+  ).default;
 
   return config;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import {promises as fs} from 'fs';
+import {createRequire} from 'module';
 
 export interface Flags {
   concurrency?: number;
@@ -20,10 +21,16 @@ export interface Flags {
   urlRewriteReplace?: string;
 }
 
+const validConfigExtensions = ['js', 'mjs', 'cjs','json'];
+
 export async function getConfig(flags: Flags) {
   // check to see if a config file path was passed
   const configPath = flags.config || 'linkinator.config.json';
-  let config: Flags = await parseConfigFile(configPath);
+  let config: Flags = {};
+
+  if (flags.config) {
+    config = await parseConfigFile(configPath);
+  }
   const strippedFlags = Object.assign({}, flags);
   Object.entries(strippedFlags).forEach(([key, value]) => {
     if (
@@ -40,36 +47,60 @@ export async function getConfig(flags: Flags) {
   return config;
 }
 
-type ConfigTypes = 'js' | 'json';
+type ConfigTypes = typeof validConfigExtensions[number];
 type ConfigParser = (configPath: string) => Promise<Flags>;
 
 const configParserMap: Record<ConfigTypes, ConfigParser> = {
   js: parseJsConfigFile,
   json: parseJsonConfigFile,
+  mjs: parseModuleJsConfigFile,
+  cjs: parseCommonJsConfigFile,
 };
 
-function parseConfigFile(configPath: string): Promise<Flags> {
+async function parseConfigFile(configPath: string): Promise<Flags> {
   const typeOfConfig = getTypeOfConfig(configPath);
 
   const configParser = configParserMap[typeOfConfig];
 
-  return configParser(configPath);
+  if (configParser) {
+    return configParser(configPath);
+  }
+
+  throw new Error(`Config file ${configPath} is invalid`);
 }
 
 function getTypeOfConfig(configPath: string): ConfigTypes {
-  const configFileExtension: string = configPath.slice(
-    configPath.lastIndexOf('.') + 1
-  );
+  const lastDotIndex = configPath.lastIndexOf('.');
 
-  if (['js', 'json'].includes(configFileExtension)) {
+  // Returning json in case file doesn't have an extension for backward compatibility
+  if (lastDotIndex === -1) return 'json';
+
+  const configFileExtension: string = configPath.slice(lastDotIndex + 1);
+
+  if (validConfigExtensions.includes(configFileExtension)) {
     return configFileExtension as ConfigTypes;
   }
 
   throw new Error('Config file should be either of js, json');
 }
 
+async function parseModuleJsConfigFile(configPath: string): Promise<Flags> {
+  const config = (await import(configPath)).default;
+
+  return config;
+}
+
+async function parseCommonJsConfigFile(configPath: string): Promise<Flags> {
+  const require = createRequire(import.meta.url);
+  const config = require(configPath);
+  return config;
+}
+
 async function parseJsConfigFile(configPath: string): Promise<Flags> {
-  return {};
+  // TODO: Added support for both commonjs & ES Modules
+  const config = (await import(configPath)).default;
+
+  return config;
 }
 
 async function parseJsonConfigFile(configPath: string): Promise<Flags> {

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,23 +23,7 @@ export interface Flags {
 export async function getConfig(flags: Flags) {
   // check to see if a config file path was passed
   const configPath = flags.config || 'linkinator.config.json';
-  let configData: string | undefined;
-  try {
-    configData = await fs.readFile(configPath, {encoding: 'utf8'});
-  } catch (e) {
-    if (flags.config) {
-      console.error(`Unable to find config file ${flags.config}`);
-      throw e;
-    }
-  }
-
-  let config: Flags = {};
-  if (configData) {
-    config = JSON.parse(configData);
-  }
-  // `meow` is set up to pass boolean flags as `undefined` if not passed.
-  // copy the struct, and delete properties that are `undefined` so the merge
-  // doesn't blast away config level settings.
+  let config: Flags = await parseConfigFile(configPath);
   const strippedFlags = Object.assign({}, flags);
   Object.entries(strippedFlags).forEach(([key, value]) => {
     if (
@@ -54,4 +38,48 @@ export async function getConfig(flags: Flags) {
   // with CLI flags getting precedence
   config = Object.assign({}, config, strippedFlags);
   return config;
+}
+
+type ConfigTypes = 'js' | 'json';
+type ConfigParser = (configPath: string) => Promise<Flags>;
+
+const configParserMap: Record<ConfigTypes, ConfigParser> = {
+  js: parseJsConfigFile,
+  json: parseJsonConfigFile,
+};
+
+function parseConfigFile(configPath: string): Promise<Flags> {
+  const typeOfConfig = getTypeOfConfig(configPath);
+
+  const configParser = configParserMap[typeOfConfig];
+
+  return configParser(configPath);
+}
+
+function getTypeOfConfig(configPath: string): ConfigTypes {
+  const configFileExtension: string = configPath.slice(
+    configPath.lastIndexOf('.') + 1
+  );
+
+  if (['js', 'json'].includes(configFileExtension)) {
+    return configFileExtension as ConfigTypes;
+  }
+
+  throw new Error('Config file should be either of js, json');
+}
+
+async function parseJsConfigFile(configPath: string): Promise<Flags> {
+  return {};
+}
+
+async function parseJsonConfigFile(configPath: string): Promise<Flags> {
+  try {
+    const configFileContents: string = await fs.readFile(configPath, {
+      encoding: 'utf-8',
+    });
+    return JSON.parse(configFileContents);
+  } catch (e) {
+    console.error(`Unable to read or parse the JSON config file ${configPath}`);
+    throw e;
+  }
 }

--- a/test/fixtures/config/linkinator.config.cjs
+++ b/test/fixtures/config/linkinator.config.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  "format": "json",
+  "recurse": true,
+  "silent": true,
+  "concurrency": 17,
+  "skip": "🌳",
+  "directoryListing": false
+}

--- a/test/fixtures/config/linkinator.config.cjs
+++ b/test/fixtures/config/linkinator.config.cjs
@@ -1,8 +1,8 @@
 module.exports = {
-  "format": "json",
-  "recurse": true,
-  "silent": true,
-  "concurrency": 17,
-  "skip": "🌳",
-  "directoryListing": false
-}
+  format: 'json',
+  recurse: true,
+  silent: true,
+  concurrency: 17,
+  skip: '🌊',
+  directoryListing: false,
+};

--- a/test/fixtures/config/linkinator.config.invalid.json
+++ b/test/fixtures/config/linkinator.config.invalid.json
@@ -1,0 +1,8 @@
+{
+  "format": "json",
+  "recurse": true,
+  "silent": true,
+  "concurrency": 17,
+  "skip": "🌳",
+  "directoryListing": false,
+}

--- a/test/fixtures/config/linkinator.config.js
+++ b/test/fixtures/config/linkinator.config.js
@@ -1,8 +1,8 @@
 export default {
-  "format": "json",
-  "recurse": true,
-  "silent": true,
-  "concurrency": 17,
-  "skip": "🌳",
-  "directoryListing": false
-}
+  format: 'json',
+  recurse: true,
+  silent: true,
+  concurrency: 17,
+  skip: '🌛',
+  directoryListing: false,
+};

--- a/test/fixtures/config/linkinator.config.js
+++ b/test/fixtures/config/linkinator.config.js
@@ -1,0 +1,8 @@
+export default {
+  "format": "json",
+  "recurse": true,
+  "silent": true,
+  "concurrency": 17,
+  "skip": "🌳",
+  "directoryListing": false
+}

--- a/test/fixtures/config/linkinator.config.mjs
+++ b/test/fixtures/config/linkinator.config.mjs
@@ -1,0 +1,8 @@
+export default {
+  "format": "json",
+  "recurse": true,
+  "silent": true,
+  "concurrency": 17,
+  "skip": "🌳",
+  "directoryListing": false
+}

--- a/test/fixtures/config/linkinator.config.mjs
+++ b/test/fixtures/config/linkinator.config.mjs
@@ -1,8 +1,8 @@
 export default {
-  "format": "json",
-  "recurse": true,
-  "silent": true,
-  "concurrency": 17,
-  "skip": "🌳",
-  "directoryListing": false
-}
+  format: 'json',
+  recurse: true,
+  silent: true,
+  concurrency: 17,
+  skip: '🪐',
+  directoryListing: false,
+};

--- a/test/test.config.ts
+++ b/test/test.config.ts
@@ -72,6 +72,11 @@ describe('config', () => {
 
       assert.deepStrictEqual(config, expected);
     });
+
+    it('should throw with reasonable message if json file is in invalid format ', async () => {
+      const configPath = 'test/fixtures/config/linkinator.config.invalid.json';
+      assert.rejects(getConfig({config: configPath}), /SyntaxError:.+in JSON/);
+    });
   });
 
   describe('js config file', () => {

--- a/test/test.config.ts
+++ b/test/test.config.ts
@@ -23,16 +23,18 @@ describe('config', () => {
       config: '/path/does/not/exist',
     };
     await assert.rejects(getConfig(cfg), /ENOENT: no such file or directory/);
+
+    await assert.rejects(
+      getConfig({config: '/path.dot/does/not/exist'}),
+      /ENOENT: no such file or directory/
+    );
   });
 
-  it('should allow reading from a config file', async () => {
-    const configPath = path.resolve(
-      'test/fixtures/config/linkinator.config.json'
+  it('should throw a reasonable message if invalid extension is passed', async () => {
+    await assert.rejects(
+      getConfig({config: 'invalid_extension.cfg'}),
+      /Config file should be either of extensions/
     );
-    const expected = JSON.parse(await fs.readFile(configPath, 'utf-8'));
-    const config = await getConfig({config: configPath});
-    delete config.config;
-    assert.deepStrictEqual(config, expected);
   });
 
   it('should merge config settings from the CLI and object', async () => {
@@ -48,51 +50,135 @@ describe('config', () => {
     delete config.config;
     assert.deepStrictEqual(config, expected);
   });
-  it('should parse config file on passing .js config file', async () => {
-    const configPath = path.resolve(
-      'test/fixtures/config/linkinator.config.js'
-    );
-    const actualConfig = await getConfig({config: configPath});
-    const expectedConfig = {
-      format: 'json',
-      recurse: true,
-      silent: true,
-      concurrency: 17,
-      skip: '🌳',
-      directoryListing: false,
-    };
-    assert.deepStrictEqual(actualConfig, expectedConfig);
+
+  describe('json config file', () => {
+    it('should parse a json config file with absolute path', async () => {
+      const configPath = path.resolve(
+        'test/fixtures/config/linkinator.config.json'
+      );
+
+      const expected = JSON.parse(await fs.readFile(configPath, 'utf-8'));
+      const config = await getConfig({config: configPath});
+      delete config.config;
+
+      assert.deepStrictEqual(config, expected);
+    });
+
+    it('should parse a json config file with relative path', async () => {
+      const configPath = 'test/fixtures/config/linkinator.config.json';
+      const expected = JSON.parse(await fs.readFile(configPath, 'utf-8'));
+      const config = await getConfig({config: configPath});
+      delete config.config;
+
+      assert.deepStrictEqual(config, expected);
+    });
   });
 
-  it('should parse config file on passing .mjs config file', async () => {
-    const configPath = path.resolve(
-      'test/fixtures/config/linkinator.config.mjs'
-    );
-    const actualConfig = await getConfig({config: configPath});
-    const expectedConfig = {
-      format: 'json',
-      recurse: true,
-      silent: true,
-      concurrency: 17,
-      skip: '🌳',
-      directoryListing: false,
-    };
-    assert.deepStrictEqual(actualConfig, expectedConfig);
+  describe('js config file', () => {
+    it('should import .js config file with relative path', async () => {
+      const configPath = 'test/fixtures/config/linkinator.config.js';
+      const actualConfig = await getConfig({config: configPath});
+      const expectedConfig = {
+        format: 'json',
+        recurse: true,
+        silent: true,
+        concurrency: 17,
+        skip: '🌛',
+        directoryListing: false,
+      };
+      delete actualConfig.config;
+
+      assert.deepStrictEqual(actualConfig, expectedConfig);
+    });
+
+    it('should import .js config file with absolute path', async () => {
+      const configPath = path.resolve(
+        'test/fixtures/config/linkinator.config.js'
+      );
+      const actualConfig = await getConfig({config: configPath});
+      const expectedConfig = {
+        format: 'json',
+        recurse: true,
+        silent: true,
+        concurrency: 17,
+        skip: '🌛',
+        directoryListing: false,
+      };
+      delete actualConfig.config;
+
+      assert.deepStrictEqual(actualConfig, expectedConfig);
+    });
   });
 
-  it('should parse config file on passing .cjs config file', async () => {
-    const configPath = path.resolve(
-      'test/fixtures/config/linkinator.config.cjs'
-    );
-    const actualConfig = await getConfig({config: configPath});
-    const expectedConfig = {
-      format: 'json',
-      recurse: true,
-      silent: true,
-      concurrency: 17,
-      skip: '🌳',
-      directoryListing: false,
-    };
-    assert.deepStrictEqual(actualConfig, expectedConfig);
+  describe('.mjs config file', () => {
+    it('should import .mjs config file with relative path', async () => {
+      const configPath = 'test/fixtures/config/linkinator.config.mjs';
+      const actualConfig = await getConfig({config: configPath});
+      const expectedConfig = {
+        format: 'json',
+        recurse: true,
+        silent: true,
+        concurrency: 17,
+        skip: '🪐',
+        directoryListing: false,
+      };
+      delete actualConfig.config;
+
+      assert.deepStrictEqual(actualConfig, expectedConfig);
+    });
+
+    it('should import .mjs config with absolute path', async () => {
+      const configPath = path.resolve(
+        'test/fixtures/config/linkinator.config.mjs'
+      );
+      const actualConfig = await getConfig({config: configPath});
+      const expectedConfig = {
+        format: 'json',
+        recurse: true,
+        silent: true,
+        concurrency: 17,
+        skip: '🪐',
+        directoryListing: false,
+      };
+      delete actualConfig.config;
+
+      assert.deepStrictEqual(actualConfig, expectedConfig);
+    });
+  });
+
+  describe('.cjs config file', () => {
+    it('should import cjs config with relative path', async () => {
+      const configPath = 'test/fixtures/config/linkinator.config.cjs';
+      const actualConfig = await getConfig({config: configPath});
+      const expectedConfig = {
+        format: 'json',
+        recurse: true,
+        silent: true,
+        concurrency: 17,
+        skip: '🌊',
+        directoryListing: false,
+      };
+      delete actualConfig.config;
+
+      assert.deepStrictEqual(actualConfig, expectedConfig);
+    });
+
+    it('should import cjs config with absolute path', async () => {
+      const configPath = path.resolve(
+        'test/fixtures/config/linkinator.config.cjs'
+      );
+      const actualConfig = await getConfig({config: configPath});
+      const expectedConfig = {
+        format: 'json',
+        recurse: true,
+        silent: true,
+        concurrency: 17,
+        skip: '🌊',
+        directoryListing: false,
+      };
+      delete actualConfig.config;
+
+      assert.deepStrictEqual(actualConfig, expectedConfig);
+    });
   });
 });

--- a/test/test.config.ts
+++ b/test/test.config.ts
@@ -48,4 +48,51 @@ describe('config', () => {
     delete config.config;
     assert.deepStrictEqual(config, expected);
   });
+  it('should parse config file on passing .js config file', async () => {
+    const configPath = path.resolve(
+      'test/fixtures/config/linkinator.config.js'
+    );
+    const actualConfig = await getConfig({config: configPath});
+    const expectedConfig = {
+      format: 'json',
+      recurse: true,
+      silent: true,
+      concurrency: 17,
+      skip: '🌳',
+      directoryListing: false,
+    };
+    assert.deepStrictEqual(actualConfig, expectedConfig);
+  });
+
+  it('should parse config file on passing .mjs config file', async () => {
+    const configPath = path.resolve(
+      'test/fixtures/config/linkinator.config.mjs'
+    );
+    const actualConfig = await getConfig({config: configPath});
+    const expectedConfig = {
+      format: 'json',
+      recurse: true,
+      silent: true,
+      concurrency: 17,
+      skip: '🌳',
+      directoryListing: false,
+    };
+    assert.deepStrictEqual(actualConfig, expectedConfig);
+  });
+
+  it('should parse config file on passing .cjs config file', async () => {
+    const configPath = path.resolve(
+      'test/fixtures/config/linkinator.config.cjs'
+    );
+    const actualConfig = await getConfig({config: configPath});
+    const expectedConfig = {
+      format: 'json',
+      recurse: true,
+      silent: true,
+      concurrency: 17,
+      skip: '🌳',
+      directoryListing: false,
+    };
+    assert.deepStrictEqual(actualConfig, expectedConfig);
+  });
 });


### PR DESCRIPTION
### What is the requirement?
Add support for JS based config file like .js, .mjs & .cjs

### What are the detailed changes?
- In `config.ts` added following functions
   - `getTypeOfConfig()` - for extract the file extension of config file & throw exception on invalid extension
   - `importConfigFile()` - for importing javascript config files
   - `readJsonConfigFile()` - for reading & parsing JSON based config file
   - `parseConfigFile()` - parent function encapsulating the logic to detect & call right function to load the config based on type
- Default format of config file is considered as JSON if no extension is provided, so as to maintain backward compatibility

### Is there a github issue it fixes?
Fixes: #504
