### PR TITLE
fix: remove file import prefix to please ncc

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,6 @@
 
 import meow from 'meow';
 import chalk from 'chalk';
-import {URL} from 'url';
 import {Flags, getConfig} from './config.js';
 import {Format, Logger, LogLevel} from './logger.js';
 import {

--- a/src/config.ts
+++ b/src/config.ts
@@ -83,8 +83,13 @@ function getTypeOfConfig(configPath: string): ConfigExtensions {
 }
 
 async function importConfigFile(configPath: string): Promise<Flags> {
-  const config = (await import(path.relative(process.cwd(), configPath)))
-    .default;
+  // Use a filthy hack to prevent ncc / webpack from trying to process
+  // the runtime dynamic import.  This hurt me more than it disgusts
+  // whoever is reading the code.
+  const _import = new Function('p', 'return import(p)');
+  const config = (
+    await _import(`file://${path.resolve(process.cwd(), configPath)}`)
+  ).default;
   return config;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -83,7 +83,7 @@ function getTypeOfConfig(configPath: string): ConfigExtensions {
 }
 
 async function importConfigFile(configPath: string): Promise<Flags> {
-  const config = (await import(path.resolve(process.cwd(), configPath)))
+  const config = (await import(path.relative(process.cwd(), configPath)))
     .default;
   return config;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -83,10 +83,8 @@ function getTypeOfConfig(configPath: string): ConfigExtensions {
 }
 
 async function importConfigFile(configPath: string): Promise<Flags> {
-  const config = (
-    await import(`file://${path.resolve(process.cwd(), configPath)}`)
-  ).default;
-
+  const config = (await import(path.resolve(process.cwd(), configPath)))
+    .default;
   return config;
 }
 


### PR DESCRIPTION
The `file://` prefix on the dynamic import statement for config was breaking ncc in `linkinator-action`.  The tests still pass with this change, and it appears to still work ..... 🤷 