### PR TITLE
`Retry-After` header, support non-standard formats

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -406,11 +406,21 @@ export class LinkChecker extends EventEmitter {
 
     // The `retry-after` header can come in either <seconds> or
     // A specific date to go check.
-    let retryAfter = Number(retryAfterRaw) * 1000 + Date.now();
+    let retryAfter = Number(
+      // handle invalid response ending in `s`
+      retryAfterRaw.replace(/^(\d+)s$/,'$1')
+    ) * 1000 + Date.now();
     if (isNaN(retryAfter)) {
       retryAfter = Date.parse(retryAfterRaw);
       if (isNaN(retryAfter)) {
-        return false;
+        if (/^\d+m\d+s$/.test(retryAfterRaw)) {
+          const retryAfterMatches = retryAfterRaw.match(/^(\d+)m(\d+)s$/);
+          retryAfter = (
+            Number(retryAfterMatches[1]) * 60 + Number(retryAfterMatches[2])
+          ) * 1000 + Date.now();
+        } else {
+          return false;
+        }
       }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -406,18 +406,23 @@ export class LinkChecker extends EventEmitter {
 
     // The `retry-after` header can come in either <seconds> or
     // A specific date to go check.
-    let retryAfter = Number(
-      // handle invalid response ending in `s`
-      retryAfterRaw.replace(/^(\d+)s$/,'$1')
-    ) * 1000 + Date.now();
+    let retryAfter =
+      Number(
+        // handle invalid response ending in `s`
+        retryAfterRaw.replace(/^(\d+)s$/, '$1')
+      ) *
+        1000 +
+      Date.now();
     if (isNaN(retryAfter)) {
       retryAfter = Date.parse(retryAfterRaw);
       if (isNaN(retryAfter)) {
+        // handle invalid response in format `1m30s`
         if (/^\d+m\d+s$/.test(retryAfterRaw)) {
           const retryAfterMatches = retryAfterRaw.match(/^(\d+)m(\d+)s$/);
-          retryAfter = (
-            Number(retryAfterMatches[1]) * 60 + Number(retryAfterMatches[2])
-          ) * 1000 + Date.now();
+          retryAfter =
+            (Number(retryAfterMatches[1]) * 60 + Number(retryAfterMatches[2])) *
+              1000 +
+            Date.now();
         } else {
           return false;
         }


### PR DESCRIPTION
I encountered a website (powered by https://www.civicplus.com/civicengage/local-government-website-design ) which adds an `s` suffix, e.g. `30s` instead of `30`.

While looking into it, I found this thread, which discusses another non-standard format, `1m0s`: https://github.com/urllib3/urllib3/issues/1822

This PR adds support for both of these non-standard formats. AKA invalid formats, but given that it's better to correctly parse the value and respect it (vs. ignoring it), seems worth doing.

Decided to pull these changes out into a `parseRetryAfter` method  for readability. Doing so made it easy to get rid of the nested `if`s:

```js
    // The `retry-after` header can come in either <seconds> or
    // A specific date to go check.
    let retryAfter = Number(retryAfterRaw) * 1000 + Date.now();
    if (isNaN(retryAfter)) {
      retryAfter = Date.parse(retryAfterRaw);
      if (isNaN(retryAfter)) {
        // handle invalid response in formats `1m30s` or `30s`
        const matches = retryAfterRaw.match(/^(?:(\d+)m)?(\d+)s$/);
        if (matches) {
          retryAfter =
            (Number(matches[1] || 0) * 60 + Number(matches[2])) * 1000 +
            Date.now();
        } else {
          return false;
        }
      }
    }
```