### PR TITLE
fix: add declaration true to compilerOptions to generate d.ts files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "strict": true,
     "target": "ES2022",
+    "declaration": true,
     "rootDir": ".",
     "outDir": "build",
     "module": "Node16",


### PR DESCRIPTION
Hi @JustinBeckwith!  I noticed that since `6.0.0` there were no `.d.ts` files generated anymore into the build folder.

I found out it was because of [this line](https://github.com/JustinBeckwith/linkinator/commit/351a7c9ebf46d48a5d05b51d8c390f398eba6af1#diff-b55cdbef4907b7045f32cc5360d48d262cca5f94062e353089f189f4460039e0L2). Because of that config missing, we lost `"declaration": true`.

If this was not intended, maybe it's worth adding it? Thanks!