### PR TITLE
Fix broken redirect

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -50,7 +50,10 @@ async function handleRequest(
 	root: string,
 	options: WebServerOptions,
 ) {
-	const requestUrl = new URL(request.url || '/', `http://localhost:${options.port}`);
+	const requestUrl = new URL(
+		request.url || '/',
+		`http://localhost:${options.port}`,
+	);
 	const pathParts = requestUrl.pathname
 		.split('/')
 		.filter(Boolean)
@@ -75,7 +78,6 @@ async function handleRequest(
 		const stats = await fs.stat(localPath);
 		const isDirectory = stats.isDirectory();
 		if (isDirectory) {
-
 			const redirectUrl = new URL(requestUrl);
 			if (!redirectUrl.pathname.endsWith('/')) {
 				redirectUrl.pathname += '/';

--- a/src/server.ts
+++ b/src/server.ts
@@ -50,14 +50,14 @@ async function handleRequest(
 	root: string,
 	options: WebServerOptions,
 ) {
-	const url = new URL(request.url || '/', `http://localhost:${options.port}`);
-	const pathParts = url.pathname
+	const requestUrl = new URL(request.url || '/', `http://localhost:${options.port}`);
+	const pathParts = requestUrl.pathname
 		.split('/')
 		.filter(Boolean)
 		// eslint-disable-next-line unicorn/no-array-callback-reference
 		.map(decodeURIComponent);
 	const originalPath = path.join(root, ...pathParts);
-	if (url.pathname.endsWith('/')) {
+	if (requestUrl.pathname.endsWith('/')) {
 		pathParts.push('index.html');
 	}
 
@@ -75,12 +75,18 @@ async function handleRequest(
 		const stats = await fs.stat(localPath);
 		const isDirectory = stats.isDirectory();
 		if (isDirectory) {
+
+			const redirectUrl = new URL(requestUrl);
+			if (!redirectUrl.pathname.endsWith('/')) {
+				redirectUrl.pathname += '/';
+			}
+
 			// This means we got a path with no / at the end!
 			const document = "<html><body>Redirectin'</body></html>";
 			response.statusCode = 301;
 			response.setHeader('Content-Type', 'text/html; charset=UTF-8');
 			response.setHeader('Content-Length', Buffer.byteLength(document));
-			response.setHeader('Location', request.url + '/');
+			response.setHeader('Location', redirectUrl.href);
 			response.end(document);
 			return;
 		}


### PR DESCRIPTION
This fix covers an edgecase when a link that has search params and resolves to a directory
(think of `/checkout?services=setup-cctv` which resolves to a file `dist/checkout/index.html`) is reported as broken.

The issue lies in an oversight in [src/server.ts:83](https://github.com/JustinBeckwith/linkinator/blob/b010033d65f64e828b97133ec731d666a672d01a/src/server.ts#L83), where request url is assumed to not have search params when a slash appended to it to implement a directory redirect.

It's fixed with actually parsing URL and appending slash only to pathname instead of the entire url string. Also, I implemented it as a separate URL object to not make things complicated - one object for the original URL and the other for redirect URL specifically.