### PR TITLE
Add support for filtering by status code

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -83,6 +83,9 @@ const cli = meow(
           Override the default verbosity for this command. Available options are
           'debug', 'info', 'warning', 'error', and 'none'.  Defaults to 'warning'.
 
+      --exclude-statuses
+          Comma-separated list of HTTP status codes to exclude from the results.
+
     Examples
       $ linkinator docs/
       $ linkinator https://www.google.com
@@ -110,6 +113,7 @@ const cli = meow(
 			retryErrorsJitter: { type: 'number', default: 3000 },
 			urlRewriteSearch: { type: 'string' },
 			urlReWriteReplace: { type: 'string' },
+			excludeStatuses: { type: 'string' },
 		},
 		booleanDefault: undefined,
 	},
@@ -195,6 +199,9 @@ async function main() {
 		retryErrors: flags.retryErrors,
 		retryErrorsCount: Number(flags.retryErrorsCount),
 		retryErrorsJitter: Number(flags.retryErrorsJitter),
+		excludeStatuses: flags.excludeStatuses
+			? flags.excludeStatuses.split(',').map(Number)
+			: undefined,
 	};
 	if (flags.skip) {
 		if (typeof flags.skip === 'string') {

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,7 @@ export type Flags = {
 	retryErrorsJitter?: number;
 	urlRewriteSearch?: string;
 	urlRewriteReplace?: string;
+	excludeStatuses?: string;
 };
 
 const validConfigExtensions = ['.js', '.mjs', '.cjs', '.json'];

--- a/src/index.ts
+++ b/src/index.ts
@@ -312,6 +312,11 @@ export class LinkChecker extends EventEmitter {
 			shouldRecurse = isHtml(response);
 		}
 
+		// Check if the status code should be excluded
+		if (options.checkOptions.excludeStatuses?.includes(status)) {
+			return;
+		}
+
 		// If retryErrors is enabled, retry 5xx and 0 status (which indicates
 		// a network error likely occurred):
 		if (this.shouldRetryOnError(status, options)) {

--- a/src/options.ts
+++ b/src/options.ts
@@ -24,6 +24,7 @@ export type CheckOptions = {
 	retryErrorsJitter?: number;
 	urlRewriteExpressions?: UrlRewriteExpression[];
 	userAgent?: string;
+	excludeStatuses?: number[];
 };
 
 export type InternalCheckOptions = {

--- a/test/fixtures/exclude-status/index.html
+++ b/test/fixtures/exclude-status/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body>
+  <a href="http://fake.local/">OK Link</a>
+  <a href="http://fake.local/forbidden">Forbidden Link</a>
+  <a href="http://fake.local/method-not-allowed">Method Not Allowed Link</a>
+  <a href="http://fake.local/error">Error Link</a>
+</body>
+</html>


### PR DESCRIPTION
E.g. you can use  --exclude-statuses to skip links that are 403.

https://github.com/JustinBeckwith/linkinator/issues/627

Feedback welcome!