### PR TITLE
feat: add ability to pass in additional request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ $ linkinator LOCATIONS [ --arguments ]
 
     --format, -f
         Return the data in CSV or JSON format.
-
+    
+    --header, -h
+	  		List of additional headers to be include in the request. use key:value notation.
+        
     --help
         Show this command.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,6 +38,9 @@ const cli = meow(
       --format, -f
           Return the data in CSV or JSON format.
 
+	  --header, -h
+	  		List of additional headers to be include in the request. use key:value notation.
+
       --help
           Show this command.
 
@@ -76,8 +79,8 @@ const cli = meow(
       --url-rewrite-replace
           Expression used to replace search content.  Must be used with --url-rewrite-search.
 
-			--user-agent
-					The user agent passed in all HTTP requests. Defaults to 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36'
+	--user-agent
+		  The user agent passed in all HTTP requests. Defaults to 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36'
 
       --verbosity
           Override the default verbosity for this command. Available options are
@@ -110,6 +113,7 @@ const cli = meow(
 			retryErrorsJitter: { type: 'number', default: 3000 },
 			urlRewriteSearch: { type: 'string' },
 			urlReWriteReplace: { type: 'string' },
+			header: { type: 'string', shortFlag: 'h', isMultiple: true },
 		},
 		booleanDefault: undefined,
 	},
@@ -137,6 +141,13 @@ async function main() {
 	const verbosity = parseVerbosity(flags);
 	const format = parseFormat(flags);
 	const logger = new Logger(verbosity, format);
+	const header = flags.header ?? [];
+	const headers = Object.fromEntries(
+		header.map((item) => {
+			const [key, value] = item.split(':');
+			return [key, value];
+		}),
+	);
 
 	logger.error(`🏊‍♂️ crawling ${cli.input.join(' ')}`);
 
@@ -195,6 +206,7 @@ async function main() {
 		retryErrors: flags.retryErrors,
 		retryErrorsCount: Number(flags.retryErrorsCount),
 		retryErrorsJitter: Number(flags.retryErrorsJitter),
+		headers,
 	};
 	if (flags.skip) {
 		if (typeof flags.skip === 'string') {

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,7 @@ export type Flags = {
 	retryErrorsJitter?: number;
 	urlRewriteSearch?: string;
 	urlRewriteReplace?: string;
+	header?: string[];
 };
 
 const validConfigExtensions = ['.js', '.mjs', '.cjs', '.json'];

--- a/src/index.ts
+++ b/src/index.ts
@@ -246,12 +246,13 @@ export class LinkChecker extends EventEmitter {
 		let state = LinkState.BROKEN;
 		let shouldRecurse = false;
 		let response: GaxiosResponse<Readable> | undefined;
+		const headers = options.checkOptions.headers;
 		const failures: Array<Error | GaxiosResponse> = [];
 		try {
 			response = await request<Readable>({
 				method: options.crawl ? 'GET' : 'HEAD',
 				url: options.url.href,
-				headers: { 'User-Agent': options.checkOptions.userAgent },
+				headers,
 				responseType: 'stream',
 				validateStatus: () => true,
 				timeout: options.checkOptions.timeout,
@@ -265,7 +266,7 @@ export class LinkChecker extends EventEmitter {
 				response = await request<Readable>({
 					method: 'GET',
 					url: options.url.href,
-					headers: { 'User-Agent': options.checkOptions.userAgent },
+					headers,
 					responseType: 'stream',
 					validateStatus: () => true,
 					timeout: options.checkOptions.timeout,
@@ -295,7 +296,7 @@ export class LinkChecker extends EventEmitter {
 					url: options.url.href,
 					responseType: 'stream',
 					validateStatus: () => true,
-					headers: { 'User-Agent': options.checkOptions.userAgent },
+					headers,
 					timeout: options.checkOptions.timeout,
 				});
 				if (this.shouldRetryAfter(response, options)) {

--- a/src/options.ts
+++ b/src/options.ts
@@ -24,6 +24,7 @@ export type CheckOptions = {
 	retryErrorsJitter?: number;
 	urlRewriteExpressions?: UrlRewriteExpression[];
 	userAgent?: string;
+	headers?: Record<string, string>;
 };
 
 export type InternalCheckOptions = {
@@ -42,7 +43,6 @@ export async function processOptions(
 	options_: CheckOptions,
 ): Promise<InternalCheckOptions> {
 	const options: InternalCheckOptions = { ...options_ };
-
 	// Ensure at least one path is provided
 	if (options.path.length === 0) {
 		throw new Error('At least one path must be provided');
@@ -80,6 +80,10 @@ export async function processOptions(
 	}
 
 	options.userAgent = options.userAgent ?? DEFAULT_USER_AGENT;
+	options.headers = {
+		'User-Agent': options.userAgent,
+		...(options.headers ?? {}),
+	};
 	options.serverRoot &&= path.normalize(options.serverRoot);
 
 	// Expand globs into paths

--- a/test/test.index.ts
+++ b/test/test.index.ts
@@ -473,6 +473,42 @@ describe('linkinator', () => {
 		}
 	});
 
+	it('should use though additional headers if passed', async () => {
+		const scopes = [
+			nock('http://fake.local')
+				.get('/', undefined, {
+					reqheaders: {
+						'User-Agent': DEFAULT_USER_AGENT,
+						'X-My-Header': 'my-value',
+					},
+				})
+				.replyWithFile(200, 'test/fixtures/local/index.html', {
+					'Content-Type': 'text/html; charset=UTF-8',
+				}),
+			nock('http://fake.local')
+				.get('/page2.html', undefined, {
+					reqheaders: {
+						'User-Agent': DEFAULT_USER_AGENT,
+						'X-My-Header': 'my-value',
+					},
+				})
+				.replyWithFile(200, 'test/fixtures/local/page2.html', {
+					'Content-Type': 'text/html; charset=UTF-8',
+				}),
+		];
+
+		const results = await check({
+			path: 'http://fake.local',
+			headers: {
+				'X-My-Header': 'my-value',
+			},
+		});
+		assert.ok(results.passed);
+		for (const x of scopes) {
+			x.done();
+		}
+	});
+
 	it('should surface call stacks on failures in the API', async () => {
 		const results = await check({
 			path: 'http://fake.local',


### PR DESCRIPTION
Hi @JustinBeckwith , 

First off, thanks for this project, it's been really useful for auditing some of the websites I work on.

I'm now working with a site that sits behind JWT authentication, so it would be really helpful to be able to pass a cookie header containing the token with the requests.

To support this, I’ve made the associated updates, but made it more generic,  allowing  multiple headers to be passed. I also wrapped the User-Agent header into this logic so it's now set via the options as well. The existing userAgent option is still supported for backward compatibility.

Let me know if there are any changes or additions you'd suggest.
(For example, I’m aware that these headers will be applied to all requests, not just the ones requiring authentication. To keep things simple, and avoid a "review nightmare", I’ve glossed over that aspect for now).