### PR TITLE
Linkinator doesn't recurse http[s] URLs that are "above" the entrypoint

### DIFF
--- a/test/fixtures/recurseNested/sub/index.html
+++ b/test/fixtures/recurseNested/sub/index.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<a href="http://fake.local/">two levels up</a>
+</body>
+</html>

--- a/test/fixtures/recurseNested/sub/path/index.html
+++ b/test/fixtures/recurseNested/sub/path/index.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<a href="http://fake.local/sub/">one level up</a>
+</body>
+</html>


### PR DESCRIPTION
This is a draft PR, which adds a failing test to demonstrate an issue with linkinator's `recurse` option when used with http[s] entrypoints. I was trying out linkinator by pointing it at a running dev server, and noticed that despite `recurse` being enabled, it was refusing to recurse how I expected.

After digging through the code, it turns out that when you use an entrypoint like `http://fake.local/sub/path/`, linkinator considers `http://fake.local/sub/path/` to be the "root path" and refuses to recurse into links on other URLs such as `http://fake.local/sub/`.

That is, if you have a scenario where:

- `http://fake.local/sub/path/` links to `http://fake.local/sub/`; and
- `http://fake.local/sub/` links to other links

Then when you point linkinator at `http://fake.local/sub/path/`, it will currently only check the links found on `http://fake.local/sub/path/`, and will ignore the ones on `http://fake.local/sub/`.

I'm not sure if this is the intended behavior, but it feels unexpected to me, since the docs state that:

> By setting `recurse` to `true`, the crawler will follow all links on the page, and continue scanning links **on the same domain** for as long as it can go.

I could certainly see someone wanting to prevent recursion above a certain URL sub-path. That might be a useful feature for people testing path-based multi-tenant apps. Maybe linkinator should allow you to specify something akin to `serverRoot` for http[s] URLs too?