### PR TITLE
add: configurable extra headers

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,7 @@ export type Flags = {
 	retryErrorsJitter?: number;
 	urlRewriteSearch?: string;
 	urlRewriteReplace?: string;
+	extraHeaders?: { [key: string]: string };
 };
 
 const validConfigExtensions = ['.js', '.mjs', '.cjs', '.json'];

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,7 @@ type CrawlOptions = {
 	retryErrors: boolean;
 	retryErrorsCount: number;
 	retryErrorsJitter: number;
+	extraHeaders: { [key: string]: string };
 };
 
 /**
@@ -139,6 +140,7 @@ export class LinkChecker extends EventEmitter {
 					retryErrors: Boolean(options_.retryErrors),
 					retryErrorsCount: options_.retryErrorsCount ?? 5,
 					retryErrorsJitter: options_.retryErrorsJitter ?? 3000,
+					extraHeaders: options.extraHeaders ?? {},
 				});
 			});
 		}
@@ -251,7 +253,10 @@ export class LinkChecker extends EventEmitter {
 			response = await request<Readable>({
 				method: options.crawl ? 'GET' : 'HEAD',
 				url: options.url.href,
-				headers: { 'User-Agent': options.checkOptions.userAgent },
+				headers: {
+					'User-Agent': options.checkOptions.userAgent,
+					...options.extraHeaders,
+				},
 				responseType: 'stream',
 				validateStatus: () => true,
 				timeout: options.checkOptions.timeout,
@@ -393,6 +398,7 @@ export class LinkChecker extends EventEmitter {
 							retryErrors: options.retryErrors,
 							retryErrorsCount: options.retryErrorsCount,
 							retryErrorsJitter: options.retryErrorsJitter,
+							extraHeaders: options.extraHeaders,
 						});
 					});
 				}

--- a/src/options.ts
+++ b/src/options.ts
@@ -24,6 +24,7 @@ export type CheckOptions = {
 	retryErrorsJitter?: number;
 	urlRewriteExpressions?: UrlRewriteExpression[];
 	userAgent?: string;
+	extraHeaders?: { [key: string]: string };
 };
 
 export type InternalCheckOptions = {
@@ -81,6 +82,9 @@ export async function processOptions(
 
 	options.userAgent = options.userAgent ?? DEFAULT_USER_AGENT;
 	options.serverRoot &&= path.normalize(options.serverRoot);
+
+	// Add extra headers
+	options.extraHeaders = options.extraHeaders ?? {};
 
 	// Expand globs into paths
 	if (!isUrlType) {

--- a/test/test.index.ts
+++ b/test/test.index.ts
@@ -609,4 +609,19 @@ describe('linkinator', () => {
 		assert.ok(results.passed);
 		scope.done();
 	});
+
+	it('should handle extra headers', async () => {
+		const scope = nock('http://fake.local', {
+			reqheaders: { 'sec-ch-ua-platform': 'Linux' },
+		})
+			.head('/')
+			.reply(200);
+		const checker = new LinkChecker();
+		const results = await checker.check({
+			path: 'test/fixtures/basic',
+			extraHeaders: { 'sec-ch-ua-platform': 'Linux' },
+		});
+		assert.ok(results.passed);
+		scope.done();
+	});
 });


### PR DESCRIPTION
To be able to check sites that require specific headers,
I added the option to define extra headers to send with all requests.

I tried to add cli options for this but failed to understand how to do it correctly,
especially because typescript gives me a ton of errors with the pre-existing code.