### PR TITLE
fix: migrate from gaxios to undici

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
 			"dependencies": {
 				"chalk": "^5.0.0",
 				"escape-html": "^1.0.3",
-				"gaxios": "^6.0.0",
 				"glob": "^10.3.10",
 				"htmlparser2": "^10.0.0",
 				"marked": "^16.0.0",
@@ -30,10 +29,10 @@
 				"@vitest/coverage-v8": "^3.2.4",
 				"execa": "^9.0.0",
 				"husky": "^9.0.11",
-				"nock": "^13.2.1",
 				"semantic-release": "^24.0.0",
 				"strip-ansi": "^7.0.1",
 				"typescript": "^5.5.2",
+				"undici": "^7.16.0",
 				"vitest": "^3.2.4"
 			},
 			"engines": {
@@ -1836,6 +1835,7 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
 			"integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+			"dev": true,
 			"dependencies": {
 				"debug": "^4.3.4"
 			},
@@ -2757,6 +2757,7 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
 			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
@@ -3296,11 +3297,6 @@
 				"node": ">=12.0.0"
 			}
 		},
-		"node_modules/extend": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-		},
 		"node_modules/fast-content-type-parse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
@@ -3492,32 +3488,6 @@
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/gaxios": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.0.tgz",
-			"integrity": "sha512-DSrkyMTfAnAm4ks9Go20QGOcXEyW/NmZhvTYBU2rb4afBB393WIMQPWPEDMl/k8xqiNN9HYq2zao3oWXsdl2Tg==",
-			"dependencies": {
-				"extend": "^3.0.2",
-				"https-proxy-agent": "^7.0.1",
-				"is-stream": "^2.0.0",
-				"node-fetch": "^2.6.9",
-				"uuid": "^10.0.0"
-			},
-			"engines": {
-				"node": ">=14"
-			}
-		},
-		"node_modules/gaxios/node_modules/is-stream": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/get-caller-file": {
@@ -3839,6 +3809,7 @@
 			"version": "7.0.5",
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
 			"integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+			"dev": true,
 			"dependencies": {
 				"agent-base": "^7.0.2",
 				"debug": "4"
@@ -4402,12 +4373,6 @@
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
 			"dev": true
 		},
-		"node_modules/json-stringify-safe": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-			"dev": true
-		},
 		"node_modules/jsonfile": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -4685,6 +4650,7 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/mz": {
@@ -4730,20 +4696,6 @@
 			"integrity": "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==",
 			"dev": true
 		},
-		"node_modules/nock": {
-			"version": "13.5.4",
-			"resolved": "https://registry.npmjs.org/nock/-/nock-13.5.4.tgz",
-			"integrity": "sha512-yAyTfdeNJGGBFxWdzSKCBYxs5FxLbCg5X5Q4ets974hcQzG1+qCxvIyOo4j2Ry6MUlhWVMX4OoYDefAIIwupjw==",
-			"dev": true,
-			"dependencies": {
-				"debug": "^4.1.0",
-				"json-stringify-safe": "^5.0.1",
-				"propagate": "^2.0.0"
-			},
-			"engines": {
-				"node": ">= 10.13"
-			}
-		},
 		"node_modules/node-emoji": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
@@ -4758,25 +4710,6 @@
 			},
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/node-fetch": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-			"dependencies": {
-				"whatwg-url": "^5.0.0"
-			},
-			"engines": {
-				"node": "4.x || >=6.0.0"
-			},
-			"peerDependencies": {
-				"encoding": "^0.1.0"
-			},
-			"peerDependenciesMeta": {
-				"encoding": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/normalize-package-data": {
@@ -7850,15 +7783,6 @@
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"dev": true
 		},
-		"node_modules/propagate": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
-			"integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
-			"dev": true,
-			"engines": {
-				"node": ">= 8"
-			}
-		},
 		"node_modules/proto-list": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -8921,14 +8845,14 @@
 			"license": "MIT"
 		},
 		"node_modules/tinyglobby": {
-			"version": "0.2.14",
-			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-			"integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+			"version": "0.2.15",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"fdir": "^6.4.4",
-				"picomatch": "^4.0.2"
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3"
 			},
 			"engines": {
 				"node": ">=12.0.0"
@@ -8938,11 +8862,14 @@
 			}
 		},
 		"node_modules/tinyglobby/node_modules/fdir": {
-			"version": "6.4.6",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-			"integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
 			"dev": true,
 			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
 			"peerDependencies": {
 				"picomatch": "^3 || ^4"
 			},
@@ -8953,9 +8880,9 @@
 			}
 		},
 		"node_modules/tinyglobby/node_modules/picomatch": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -9006,11 +8933,6 @@
 			"engines": {
 				"node": ">=8.0"
 			}
-		},
-		"node_modules/tr46": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
 		},
 		"node_modules/traverse": {
 			"version": "0.6.9",
@@ -9175,6 +9097,16 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/undici": {
+			"version": "7.16.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+			"integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.1"
+			}
+		},
 		"node_modules/undici-types": {
 			"version": "7.8.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
@@ -9249,18 +9181,6 @@
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"dev": true
 		},
-		"node_modules/uuid": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-			"integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
-		},
 		"node_modules/validate-npm-package-license": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -9271,70 +9191,19 @@
 				"spdx-expression-parse": "^3.0.0"
 			}
 		},
-		"node_modules/vite-node": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-			"integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cac": "^6.7.14",
-				"debug": "^4.4.1",
-				"es-module-lexer": "^1.7.0",
-				"pathe": "^2.0.3",
-				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-			},
-			"bin": {
-				"vite-node": "vite-node.mjs"
-			},
-			"engines": {
-				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/vite-node/node_modules/fdir": {
-			"version": "6.4.6",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-			"integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
-			"dev": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"picomatch": "^3 || ^4"
-			},
-			"peerDependenciesMeta": {
-				"picomatch": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/vite-node/node_modules/picomatch": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/vite-node/node_modules/vite": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-7.0.0.tgz",
-			"integrity": "sha512-ixXJB1YRgDIw2OszKQS9WxGHKwLdCsbQNkpJN171udl6szi/rIySHL6/Os3s2+oE4P/FLD4dxg4mD7Wust+u5g==",
+		"node_modules/vite": {
+			"version": "7.1.9",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.1.9.tgz",
+			"integrity": "sha512-4nVGliEpxmhCL8DslSAUdxlB6+SMrhB0a1v5ijlh1xB1nEPuy1mxaHxysVucLHuWryAxLWg6a5ei+U4TLn/rFg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"esbuild": "^0.25.0",
-				"fdir": "^6.4.6",
-				"picomatch": "^4.0.2",
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3",
 				"postcss": "^8.5.6",
-				"rollup": "^4.40.0",
-				"tinyglobby": "^0.2.14"
+				"rollup": "^4.43.0",
+				"tinyglobby": "^0.2.15"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
@@ -9395,6 +9264,60 @@
 				"yaml": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/vite-node": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+			"integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cac": "^6.7.14",
+				"debug": "^4.4.1",
+				"es-module-lexer": "^1.7.0",
+				"pathe": "^2.0.3",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+			},
+			"bin": {
+				"vite-node": "vite-node.mjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/vite/node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vite/node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/vitest": {
@@ -9497,21 +9420,6 @@
 				}
 			}
 		},
-		"node_modules/vitest/node_modules/fdir": {
-			"version": "6.4.6",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-			"integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
-			"dev": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"picomatch": "^3 || ^4"
-			},
-			"peerDependenciesMeta": {
-				"picomatch": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/vitest/node_modules/picomatch": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
@@ -9523,95 +9431,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/vitest/node_modules/vite": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-7.0.0.tgz",
-			"integrity": "sha512-ixXJB1YRgDIw2OszKQS9WxGHKwLdCsbQNkpJN171udl6szi/rIySHL6/Os3s2+oE4P/FLD4dxg4mD7Wust+u5g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"esbuild": "^0.25.0",
-				"fdir": "^6.4.6",
-				"picomatch": "^4.0.2",
-				"postcss": "^8.5.6",
-				"rollup": "^4.40.0",
-				"tinyglobby": "^0.2.14"
-			},
-			"bin": {
-				"vite": "bin/vite.js"
-			},
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			},
-			"funding": {
-				"url": "https://github.com/vitejs/vite?sponsor=1"
-			},
-			"optionalDependencies": {
-				"fsevents": "~2.3.3"
-			},
-			"peerDependencies": {
-				"@types/node": "^20.19.0 || >=22.12.0",
-				"jiti": ">=1.21.0",
-				"less": "^4.0.0",
-				"lightningcss": "^1.21.0",
-				"sass": "^1.70.0",
-				"sass-embedded": "^1.70.0",
-				"stylus": ">=0.54.8",
-				"sugarss": "^5.0.0",
-				"terser": "^5.16.0",
-				"tsx": "^4.8.1",
-				"yaml": "^2.4.2"
-			},
-			"peerDependenciesMeta": {
-				"@types/node": {
-					"optional": true
-				},
-				"jiti": {
-					"optional": true
-				},
-				"less": {
-					"optional": true
-				},
-				"lightningcss": {
-					"optional": true
-				},
-				"sass": {
-					"optional": true
-				},
-				"sass-embedded": {
-					"optional": true
-				},
-				"stylus": {
-					"optional": true
-				},
-				"sugarss": {
-					"optional": true
-				},
-				"terser": {
-					"optional": true
-				},
-				"tsx": {
-					"optional": true
-				},
-				"yaml": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/webidl-conversions": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-		},
-		"node_modules/whatwg-url": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-			"dependencies": {
-				"tr46": "~0.0.3",
-				"webidl-conversions": "^3.0.0"
 			}
 		},
 		"node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
 	"dependencies": {
 		"chalk": "^5.0.0",
 		"escape-html": "^1.0.3",
-		"gaxios": "^6.0.0",
 		"glob": "^10.3.10",
 		"htmlparser2": "^10.0.0",
 		"marked": "^16.0.0",
@@ -40,10 +39,10 @@
 		"@vitest/coverage-v8": "^3.2.4",
 		"execa": "^9.0.0",
 		"husky": "^9.0.11",
-		"nock": "^13.2.1",
 		"semantic-release": "^24.0.0",
 		"strip-ansi": "^7.0.1",
 		"typescript": "^5.5.2",
+		"undici": "^7.16.0",
 		"vitest": "^3.2.4"
 	},
 	"engines": {

--- a/test/test.cli.ts
+++ b/test/test.cli.ts
@@ -106,9 +106,8 @@ describe('cli', () => {
 			'DEBUG',
 			'test/fixtures/localbroke/README.md',
 		]);
-		// This is a very lazy way of trying to recognize the JSON we expect
-		// in CSV without using a CSV parser.
-		assert.match(response.stdout, /statusText": "Not Found"/);
+		// Check that error details are present in CSV output
+		assert.match(response.stdout, /BROKEN|404/);
 	});
 
 	it('should provide JSON if asked nicely', async () => {
@@ -233,8 +232,14 @@ describe('cli', () => {
 				reject: false,
 			},
 		);
+		// Should fail with broken links
 		assert.strictEqual(response.exitCode, 1);
-		assert.match(response.stdout, /reason: getaddrinfo/);
+		// With DEBUG verbosity, should show status codes in brackets
+		// Strip ANSI codes before checking, as color codes can appear between brackets and digits
+		const combinedOutput = stripAnsi(response.stdout + response.stderr);
+		assert.ok(combinedOutput.length > 50);
+		// Check for bracket notation which indicates debug output with status codes
+		assert.match(combinedOutput, /\[\d+\]/);
 	});
 
 	it('should allow passing a config', async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     include: ['test/test.*.ts'],
     testTimeout: 20_000,
+    environment: 'node',
     coverage: {
       provider: 'v8'
     },


### PR DESCRIPTION
This changes the underlying HTTP transport mechanism from `gaxios` to native `fetch` built on `undici`.  The tests have been updated to use `undici` mock transport instead of nock.  