### PR TITLE
fix: preserve query parameters in directory redirects

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -75,11 +75,18 @@ async function handleRequest(
 		const isDirectory = stats.isDirectory();
 		if (isDirectory) {
 			// This means we got a path with no / at the end!
+			// Create a proper redirect URL that preserves query parameters
+			// Fix for issue #595 - thanks to @maddsua for the solution in PR #596
+			const redirectUrl = new URL(url);
+			if (!redirectUrl.pathname.endsWith('/')) {
+				redirectUrl.pathname += '/';
+			}
+
 			const document = "<html><body>Redirectin'</body></html>";
 			response.statusCode = 301;
 			response.setHeader('Content-Type', 'text/html; charset=UTF-8');
 			response.setHeader('Content-Length', Buffer.byteLength(document));
-			response.setHeader('Location', `${request.url}/`);
+			response.setHeader('Location', redirectUrl.href);
 			response.end(document);
 			return;
 		}

--- a/test/fixtures/server/checkout/index.html
+++ b/test/fixtures/server/checkout/index.html
@@ -1,0 +1,1 @@
+<html><body>Checkout page</body></html>

--- a/test/test.server.ts
+++ b/test/test.server.ts
@@ -88,4 +88,14 @@ describe('server', () => {
 		assert.strictEqual(response.status, 200);
 		assert.strictEqual(data, contents);
 	});
+
+	it('should handle query strings when path requires redirect to directory', async () => {
+		// This reproduces issue #595 - /checkout?services=setup-cctv
+		// where /checkout is a directory that should redirect to /checkout/
+		const url = `${rootUrl}/checkout?services=setup-cctv`;
+		const response = await undiciFetch(url);
+		const data = await response.text();
+		assert.strictEqual(response.status, 200);
+		assert.strictEqual(data, '<html><body>Checkout page</body></html>');
+	});
 });


### PR DESCRIPTION
## Summary

Fixes #595 - URLs with query parameters pointing to directories without trailing slashes were causing infinite redirect loops.

## The Problem

When accessing a URL like `/checkout?services=setup-cctv` where `checkout` is a directory, the server would incorrectly redirect to `/checkout?services=setup-cctv/` instead of `/checkout/?services=setup-cctv`. This caused an infinite redirect loop because:

1. Request: `/checkout?services=setup-cctv`
2. Redirect to: `/checkout?services=setup-cctv/` (malformed URL)
3. Browser parses as pathname: `/checkout` with query: `services=setup-cctv/`
4. Still detected as directory, redirects again
5. Loop continues until redirect limit exceeded

## The Fix

Updated `src/server.ts` to properly parse the URL and only append the trailing slash to the pathname component, preserving query parameters intact:

```typescript
const redirectUrl = new URL(url);
if (!redirectUrl.pathname.endsWith('/')) {
  redirectUrl.pathname += '/';
}
response.setHeader('Location', redirectUrl.href);
```

## Test Plan

- [x] Added regression test case for directory URLs with query parameters
- [x] All existing tests pass (136 tests)
- [x] Manually verified the redirect now produces correct Location header

## Credit

This fix is based on the work by @maddsua in PR #596, who identified this issue and provided the solution. After 16 months without review, their PR was closed. This implementation honors their contribution with proper attribution in the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)