### PR TITLE
docs: add linkinator-mcp section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,29 @@ jobs:
 
 To see all options or to learn more, visit [JustinBeckwith/linkinator-action](https://github.com/JustinBeckwith/linkinator-action).
 
+### Model Context Protocol (MCP)
+
+You can also use `linkinator` in AI assistants like Claude through the Model Context Protocol using [JustinBeckwith/linkinator-mcp](https://github.com/JustinBeckwith/linkinator-mcp).
+
+The linkinator-mcp server brings link-checking capabilities directly to AI assistants, enabling automated scanning of webpages and local files through natural language prompts.
+
+**Installation:**
+
+```sh
+npx install-mcp linkinator-mcp --client claude
+```
+
+This will automatically configure the MCP server for Claude Desktop, Claude Code, Cursor, and other compatible clients.
+
+**Usage:**
+
+Once installed, you can check links through natural language:
+- "Check all links on https://example.com"
+- "Scan my documentation recursively and validate anchor fragments"
+- "Check local files at /path/to/docs"
+
+For more details and manual configuration options, visit [JustinBeckwith/linkinator-mcp](https://github.com/JustinBeckwith/linkinator-mcp).
+
 ## API Usage
 
 ### linkinator.check(options)


### PR DESCRIPTION
## Summary
- Added a new "Model Context Protocol (MCP)" section under the GitHub Actions section in the README
- Documents the linkinator-mcp server that brings link-checking capabilities to AI assistants like Claude
- Includes installation instructions, usage examples, and link to the repository

## Test plan
- [ ] Review the new section for clarity and accuracy
- [ ] Verify all links are working
- [ ] Confirm formatting is consistent with the rest of the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)