### PR TITLE
feat: add configurable status code handling

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,8 @@ export type Flags = {
 	urlRewriteSearch?: string;
 	urlRewriteReplace?: string;
 	header?: string[];
+	statusCode?: string | string[];
+	statusCodes?: Record<string, string>;
 };
 
 const validConfigExtensions = ['.js', '.mjs', '.cjs', '.json'];

--- a/src/options.ts
+++ b/src/options.ts
@@ -8,6 +8,8 @@ export type UrlRewriteExpression = {
 	replacement: string;
 };
 
+export type StatusCodeAction = 'ok' | 'warn' | 'skip' | 'error';
+
 export type CheckOptions = {
 	concurrency?: number;
 	port?: number;
@@ -31,6 +33,7 @@ export type CheckOptions = {
 	allowInsecureCerts?: boolean;
 	checkCss?: boolean;
 	checkFragments?: boolean;
+	statusCodes?: Record<string, StatusCodeAction>;
 };
 
 export type InternalCheckOptions = {

--- a/test/fixtures/status-codes/200.html
+++ b/test/fixtures/status-codes/200.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><title>Status Code Test - 200</title></head>
+<body>
+<a href="https://example.com/success">Success Link</a>
+</body>
+</html>

--- a/test/fixtures/status-codes/403.html
+++ b/test/fixtures/status-codes/403.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><title>Status Code Test - 403</title></head>
+<body>
+<a href="https://example.com/forbidden">Forbidden Link</a>
+</body>
+</html>

--- a/test/fixtures/status-codes/404.html
+++ b/test/fixtures/status-codes/404.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><title>Status Code Test - 404</title></head>
+<body>
+<a href="https://example.com/notfound">Not Found Link</a>
+</body>
+</html>

--- a/test/fixtures/status-codes/5xx.html
+++ b/test/fixtures/status-codes/5xx.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head><title>Status Codes 5xx Test</title></head>
+<body>
+<a href="https://example.com/error">Error</a>
+<a href="https://example.com/unavailable">Unavailable</a>
+</body>
+</html>

--- a/test/fixtures/status-codes/default.html
+++ b/test/fixtures/status-codes/default.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head><title>Status Codes Default Test</title></head>
+<body>
+<a href="https://example.com/success">Success</a>
+<a href="https://example.com/notfound">Not Found</a>
+</body>
+</html>

--- a/test/fixtures/status-codes/pattern.html
+++ b/test/fixtures/status-codes/pattern.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head><title>Status Codes Pattern Test</title></head>
+<body>
+<a href="https://example.com/forbidden">Forbidden</a>
+<a href="https://example.com/notfound">Not Found</a>
+<a href="https://example.com/teapot">Teapot</a>
+</body>
+</html>

--- a/test/test.status-codes.ts
+++ b/test/test.status-codes.ts
@@ -1,0 +1,195 @@
+import { getGlobalDispatcher, MockAgent, setGlobalDispatcher } from 'undici';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LinkChecker, LinkState } from '../src/index.js';
+
+describe('status code configuration', () => {
+	let mockAgent: MockAgent;
+	let originalDispatcher: ReturnType<typeof getGlobalDispatcher>;
+
+	beforeEach(() => {
+		originalDispatcher = getGlobalDispatcher();
+		mockAgent = new MockAgent();
+		mockAgent.disableNetConnect();
+		mockAgent.enableNetConnect((host) => {
+			return host.includes('localhost') || host.includes('127.0.0.1');
+		});
+		setGlobalDispatcher(mockAgent);
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		vi.unstubAllEnvs();
+		mockAgent.assertNoPendingInterceptors();
+		await mockAgent.close();
+		setGlobalDispatcher(originalDispatcher);
+	});
+
+	it('should treat 403 as OK when configured with "ok" action', async () => {
+		const mockPool = mockAgent.get('https://example.com');
+		mockPool.intercept({ path: '/forbidden', method: 'HEAD' }).reply(403, '');
+
+		const checker = new LinkChecker();
+		const results = await checker.check({
+			path: 'test/fixtures/status-codes/403.html',
+			statusCodes: { '403': 'ok' },
+		});
+
+		const forbiddenLink = results.links.find((l) =>
+			l.url.includes('/forbidden'),
+		);
+		expect(forbiddenLink?.state).toBe(LinkState.OK);
+		expect(forbiddenLink?.status).toBe(403);
+		expect(results.passed).toBe(true);
+	});
+
+	it('should treat 403 as warning when configured with "warn" action', async () => {
+		const mockPool = mockAgent.get('https://example.com');
+		mockPool.intercept({ path: '/forbidden', method: 'HEAD' }).reply(403, '');
+
+		const checker = new LinkChecker();
+		const warnings: Array<{ url: string; status: number }> = [];
+		checker.on('statusCodeWarning', (info) => {
+			warnings.push(info);
+		});
+
+		const results = await checker.check({
+			path: 'test/fixtures/status-codes/403.html',
+			statusCodes: { '403': 'warn' },
+		});
+
+		const forbiddenLink = results.links.find((l) =>
+			l.url.includes('/forbidden'),
+		);
+		expect(forbiddenLink?.state).toBe(LinkState.OK);
+		expect(forbiddenLink?.status).toBe(403);
+		expect(results.passed).toBe(true);
+		expect(warnings.length).toBe(1);
+		expect(warnings[0].status).toBe(403);
+	});
+
+	it('should skip 404 when configured with "skip" action', async () => {
+		const mockPool = mockAgent.get('https://example.com');
+		mockPool.intercept({ path: '/notfound', method: 'HEAD' }).reply(404, '');
+
+		const checker = new LinkChecker();
+		const results = await checker.check({
+			path: 'test/fixtures/status-codes/404.html',
+			statusCodes: { '404': 'skip' },
+		});
+
+		const notFoundLink = results.links.find((l) => l.url.includes('/notfound'));
+		expect(notFoundLink?.state).toBe(LinkState.SKIPPED);
+		expect(notFoundLink?.status).toBe(404);
+		expect(results.passed).toBe(true);
+	});
+
+	it('should force 200 to error when configured with "error" action', async () => {
+		const mockPool = mockAgent.get('https://example.com');
+		mockPool.intercept({ path: '/success', method: 'HEAD' }).reply(200, '');
+
+		const checker = new LinkChecker();
+		const results = await checker.check({
+			path: 'test/fixtures/status-codes/200.html',
+			statusCodes: { '200': 'error' },
+		});
+
+		const successLink = results.links.find((l) => l.url.includes('/success'));
+		expect(successLink?.state).toBe(LinkState.BROKEN);
+		expect(successLink?.status).toBe(200);
+		expect(results.passed).toBe(false);
+	});
+
+	it('should match status code patterns like "4xx"', async () => {
+		const mockPool = mockAgent.get('https://example.com');
+		mockPool.intercept({ path: '/forbidden', method: 'HEAD' }).reply(403, '');
+		mockPool.intercept({ path: '/notfound', method: 'HEAD' }).reply(404, '');
+		mockPool
+			.intercept({ path: '/teapot', method: 'HEAD' })
+			.reply(418, "I'm a teapot");
+
+		const checker = new LinkChecker();
+		const results = await checker.check({
+			path: 'test/fixtures/status-codes/pattern.html',
+			statusCodes: { '4xx': 'warn' },
+		});
+
+		const forbiddenLink = results.links.find((l) =>
+			l.url.includes('/forbidden'),
+		);
+		const notFoundLink = results.links.find((l) => l.url.includes('/notfound'));
+		const teapotLink = results.links.find((l) => l.url.includes('/teapot'));
+
+		expect(forbiddenLink?.state).toBe(LinkState.OK);
+		expect(notFoundLink?.state).toBe(LinkState.OK);
+		expect(teapotLink?.state).toBe(LinkState.OK);
+		expect(results.passed).toBe(true);
+	});
+
+	it('should match status code patterns like "5xx"', async () => {
+		const mockPool = mockAgent.get('https://example.com');
+		mockPool.intercept({ path: '/error', method: 'HEAD' }).reply(500, '');
+		mockPool.intercept({ path: '/unavailable', method: 'HEAD' }).reply(503, '');
+
+		const checker = new LinkChecker();
+		const results = await checker.check({
+			path: 'test/fixtures/status-codes/5xx.html',
+			statusCodes: { '5xx': 'skip' },
+		});
+
+		const errorLink = results.links.find((l) => l.url.includes('/error'));
+		const unavailableLink = results.links.find((l) =>
+			l.url.includes('/unavailable'),
+		);
+
+		expect(errorLink?.state).toBe(LinkState.SKIPPED);
+		expect(unavailableLink?.state).toBe(LinkState.SKIPPED);
+		expect(results.passed).toBe(true);
+	});
+
+	it('should prioritize exact matches over patterns', async () => {
+		const mockPool = mockAgent.get('https://example.com');
+		mockPool.intercept({ path: '/forbidden', method: 'HEAD' }).reply(403, '');
+		mockPool.intercept({ path: '/notfound', method: 'HEAD' }).reply(404, '');
+		mockPool
+			.intercept({ path: '/teapot', method: 'HEAD' })
+			.reply(418, "I'm a teapot");
+
+		const checker = new LinkChecker();
+		const results = await checker.check({
+			path: 'test/fixtures/status-codes/pattern.html',
+			statusCodes: {
+				'4xx': 'warn', // General pattern
+				'404': 'skip', // Specific override
+			},
+		});
+
+		const forbiddenLink = results.links.find((l) =>
+			l.url.includes('/forbidden'),
+		);
+		const notFoundLink = results.links.find((l) => l.url.includes('/notfound'));
+
+		// 403 should match 4xx pattern (warn = OK)
+		expect(forbiddenLink?.state).toBe(LinkState.OK);
+		// 404 should match exact rule (skip)
+		expect(notFoundLink?.state).toBe(LinkState.SKIPPED);
+		expect(results.passed).toBe(true);
+	});
+
+	it('should not interfere with default behavior when no configuration', async () => {
+		const mockPool = mockAgent.get('https://example.com');
+		mockPool.intercept({ path: '/success', method: 'HEAD' }).reply(200, '');
+		mockPool.intercept({ path: '/notfound', method: 'HEAD' }).reply(404, '');
+
+		const checker = new LinkChecker();
+		const results = await checker.check({
+			path: 'test/fixtures/status-codes/default.html',
+		});
+
+		const successLink = results.links.find((l) => l.url.includes('/success'));
+		const notFoundLink = results.links.find((l) => l.url.includes('/notfound'));
+
+		expect(successLink?.state).toBe(LinkState.OK);
+		expect(notFoundLink?.state).toBe(LinkState.BROKEN);
+		expect(results.passed).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

This PR adds support for customizing how linkinator handles specific HTTP status codes, addressing both #627 and #718.

Users can now configure linkinator to treat specific status codes as warnings, skip them entirely, force them to pass, or force them to fail. This is especially useful for handling aggressive bot protection (403s) or treating certain server errors differently.

## Changes

### CLI Flag
New `--status-code` flag that accepts `CODE:ACTION` format:
```bash
linkinator . --status-code "403:warn" --status-code "5xx:skip"
```

### Config File Support
Added `statusCodes` option in `linkinator.config.json`:
```json
{
  "statusCodes": {
    "403": "warn",
    "404": "skip",
    "4xx": "warn",
    "5xx": "skip"
  }
}
```

### Available Actions
- **`ok`** - Treat as success (link passes)
- **`warn`** - Treat as success but emit a warning message
- **`skip`** - Ignore the link entirely (like bot-protected links)
- **`error`** - Force the link to fail

### Pattern Matching
- Supports specific codes (`"403"`) and patterns (`"4xx"`, `"5xx"`)
- Exact matches take priority over patterns
- Custom status codes override default behavior

## Implementation Details

- Added `StatusCodeAction` type in `src/options.ts`
- Implemented status code evaluation logic with helper functions in `src/index.ts`
- Added CLI flag parsing in `src/cli.ts`
- Extended config file support in `src/config.ts`
- Added `statusCodeWarning` event to LinkChecker
- Created comprehensive test suite (8 tests)

## Testing

✅ All 213 tests passing (including 8 new status code tests)
- Tests exact matches
- Tests pattern matches (4xx, 5xx)  
- Tests all four actions (ok, warn, skip, error)
- Tests priority (exact over pattern)
- Tests default behavior preserved

## Documentation

Updated README.md with:
- CLI flag documentation
- Config file examples
- New "Handling Specific Status Codes" section with usage examples

## Closes

Closes #627
Closes #718

🤖 Generated with [Claude Code](https://claude.com/claude-code)