### PR TITLE
fix: prevent port exhaustion by reusing HTTP agents

### DIFF
--- a/src/stream-utils.ts
+++ b/src/stream-utils.ts
@@ -1,6 +1,31 @@
 import { Readable } from 'node:stream';
 
 /**
+ * Drains a response body stream without consuming its data.
+ * This is important for connection pooling - if the body is not consumed,
+ * the underlying TCP connection may not be returned to the pool, leading
+ * to port exhaustion under high load.
+ * @param body The response body stream to drain
+ */
+export async function drainStream(
+	body: ReadableStream | Readable | undefined,
+): Promise<void> {
+	if (!body) return;
+
+	try {
+		if ('cancel' in body && typeof body.cancel === 'function') {
+			// Web ReadableStream - cancel it to release the connection
+			await body.cancel();
+		} else if ('destroy' in body && typeof body.destroy === 'function') {
+			// Node.js Readable stream - destroy it
+			body.destroy();
+		}
+	} catch {
+		// Ignore errors when draining - the connection will be cleaned up eventually
+	}
+}
+
+/**
  * Converts a response body stream to a Node.js Readable stream.
  * Handles both Web ReadableStreams (from fetch) and Node.js Readable streams (from local server).
  * @param body The response body stream


### PR DESCRIPTION
## Summary

Fixes #753

- Use a shared `undici.Agent` for `allowInsecureCerts` requests instead of creating a new agent per request
- Add `drainStream()` utility to properly release connections back to the pool
- Drain unconsumed response bodies at the end of each link check
- Export `resetSharedAgents()` for test isolation

## Root Cause

When `allowInsecureCerts` was enabled, a **new `Agent` was created for every single HTTP request** (`src/index.ts:1007-1015`). Each Agent has its own connection pool, so connections were never reused across requests, exhausting available SNAT ports.

## Changes

1. **Shared Agent for Insecure Certificates**: Created a singleton shared `Agent` configured with proper connection pooling settings (`keepAliveTimeout`, `keepAliveMaxTimeout`, `connections`)

2. **Response Body Draining**: Added `drainStream()` utility and ensured response bodies that aren't consumed are properly drained at the end of each crawl

3. **Proper Fetch Usage**: Normal requests use native `fetch()` with the global dispatcher; only `allowInsecureCerts` requests use the custom shared agent

## Test plan

- [x] All 222 tests pass
- [x] Coverage maintained: `stream-utils.ts` at 100%, `index.ts` at 95.85%
- [x] New tests added for `drainStream()` and `resetSharedAgents()`
- [x] Insecure cert tests still pass (`test/test.cert-validation.ts`, `test/test.insecure.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)