### PR TITLE
fix: make --version flag work in compiled binaries

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@
 import process from 'node:process';
 import chalk from 'chalk';
 import meow from 'meow';
+import packageJson from '../package.json' with { type: 'json' };
 import { type Flags, getConfig } from './config.js';
 import {
 	type CheckOptions,
@@ -50,6 +51,9 @@ const cli = meow(
 
 		--help
 			Show this command.
+
+		--version
+			Show the version number.
 
 		--markdown
 			Automatically parse and scan markdown if scanning from a location on disk.
@@ -134,6 +138,7 @@ const cli = meow(
 `,
 	{
 		importMeta: import.meta,
+		version: packageJson.version,
 		flags: {
 			config: { type: 'string' },
 			concurrency: { type: 'number' },

--- a/test/test.cli.ts
+++ b/test/test.cli.ts
@@ -54,6 +54,14 @@ describe('cli', () => {
 		assert.match(response.stdout, /\$ linkinator LOCATION \[ --arguments ]/);
 	});
 
+	it('should show version when --version flag is used', async () => {
+		const response = await execa(node, [linkinator, '--version']);
+		const pkg = JSON.parse(
+			fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+		) as { version: string };
+		assert.strictEqual(response.stdout.trim(), pkg.version);
+	});
+
 	it('should flag skipped links', async () => {
 		const response = await execa(node, [
 			linkinator,


### PR DESCRIPTION
## Summary

Fixes #759

The `--version` flag now works correctly in compiled binaries (e.g., `linkinator-linux`). Previously it returned "No version found" because meow couldn't locate package.json in the filesystem when the app is compiled into a standalone executable.

## Changes

- Import version from package.json at build time and pass it explicitly to meow
- Add `--version` to help documentation for better discoverability
- Add test to verify `--version` returns the correct version number

## Root Cause

When linkinator is compiled using `bun build --compile`, the package.json file isn't bundled into the standalone executable. The meow library was configured to use `importMeta: import.meta` to automatically find the version from package.json, but this doesn't work in compiled binaries since the file isn't available at runtime.

## The Fix

By explicitly importing the version from package.json at build time and passing it to meow's `version` option, the version string is now embedded in the compiled code. This makes it available in both:
- The npm package (`linkinator --version`)
- Compiled binaries (`./linkinator-linux --version`)

## Impact

This was only an issue for compiled binaries. The npm installable version would have worked fine with the original code because package.json is always included in npm packages. However, this fix improves both cases by embedding the version at build time rather than reading it at runtime.

## Test Plan

- [x] All 224 tests pass (including new `--version` test)
- [x] Verified `node build/src/cli.js --version` outputs `7.5.1`
- [x] Code passes `npm run fix` (biome linting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)