### PR TITLE
test: cover mdx repo scanning

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -153,7 +153,8 @@ export async function processOptions(
 	// Enable markdown if someone passes a flag/glob right at it
 	if (options.markdown === undefined) {
 		for (const p of options.path) {
-			if (path.extname(p).toLowerCase() === '.md') {
+			const extension = path.extname(p).toLowerCase();
+			if (extension === '.md' || extension === '.mdx') {
 				options.markdown = true;
 			}
 		}

--- a/test/fixtures/mdx-repo/LICENSE.md
+++ b/test/fixtures/mdx-repo/LICENSE.md
@@ -1,0 +1,3 @@
+The MIT License (MIT)
+
+This file exists so MDX fixture scans can verify recursive local links.

--- a/test/fixtures/mdx-repo/README.mdx
+++ b/test/fixtures/mdx-repo/README.mdx
@@ -1,0 +1,11 @@
+import Callout from './components/callout.js';
+
+export const metadata = {
+	title: 'MDX fixture',
+};
+
+# MDX Fixture
+
+<Callout type="info">This is here to prove JSX-style MDX syntax is present.</Callout>
+
+Start with the [guide](guide.mdx).

--- a/test/fixtures/mdx-repo/guide.mdx
+++ b/test/fixtures/mdx-repo/guide.mdx
@@ -1,0 +1,3 @@
+# Guide
+
+This guide links to the [license](LICENSE.md).

--- a/test/test.cli.ts
+++ b/test/test.cli.ts
@@ -39,6 +39,14 @@ describe('cli', () => {
 		assert.match(response.stderr, /Successfully scanned/);
 	});
 
+	it('should pass successful mdx scan', async () => {
+		const response = await execa(node, [
+			linkinator,
+			'test/fixtures/mdx-repo/README.mdx',
+		]);
+		assert.match(response.stderr, /Successfully scanned/);
+	});
+
 	it('should allow multiple paths', async () => {
 		const response = await execa(node, [
 			linkinator,

--- a/test/test.index.ts
+++ b/test/test.index.ts
@@ -493,6 +493,22 @@ describe('linkinator', () => {
 		assert.strictEqual(results.links.length, 3);
 	});
 
+	it('should autoscan mdx files in a repo scan', async () => {
+		const results = await check({
+			path: 'test/fixtures/mdx-repo/**/*.mdx',
+		});
+		assert.ok(results.passed);
+		assert.strictEqual(results.links.length, 3);
+		assert.strictEqual(
+			results.links.filter((x) => x.url.endsWith('guide.mdx')).length,
+			1,
+		);
+		assert.strictEqual(
+			results.links.filter((x) => x.url.endsWith('LICENSE.md')).length,
+			1,
+		);
+	});
+
 	it('should throw if a glob provides no paths to scan', async () => {
 		await expect(
 			check({


### PR DESCRIPTION
## Summary
- auto-detect  paths the same way  paths enable markdown mode
- add an MDX fixture that looks like docs content in a repo and links to another  file plus a nested markdown file
- add library and CLI coverage proving a repo scan can discover and follow MDX links end to end

## Testing
- npm test -- test/test.index.ts test/test.cli.ts