### PR TITLE
feat: add crawl delay option (closes #534)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -126,6 +126,9 @@ const cli = meow(
 		--verbosity
 			Override the default verbosity for this command. Available options are
 			'debug', 'info', 'warning', 'error', and 'none'.  Defaults to 'warning'.
+		
+		--crawl-delay
+			Number of seconds to wait between requests to the same host. Defaults to 0 (no delay).
 
 	Examples
 		$ linkinator docs/
@@ -165,6 +168,7 @@ const cli = meow(
 			urlRewriteSearch: { type: 'string' },
 			urlReWriteReplace: { type: 'string' },
 			header: { type: 'string', shortFlag: 'h', isMultiple: true },
+			crawlDelay: { type: 'number' },
 		},
 		booleanDefault: undefined,
 	},
@@ -353,6 +357,7 @@ async function main() {
 		retryErrors: flags.retryErrors,
 		retryErrorsCount: Number(flags.retryErrorsCount),
 		retryErrorsJitter: Number(flags.retryErrorsJitter),
+		crawlDelay: Number(flags.crawlDelay),
 		headers,
 	};
 	if (flags.skip) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,7 @@ export type Flags = {
 	header?: string[];
 	statusCode?: string | string[];
 	statusCodes?: Record<string, string>;
+	crawlDelay?: number;
 };
 
 const validConfigExtensions = ['.js', '.mjs', '.cjs', '.json'];

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,6 +152,7 @@ type CrawlOptions = {
 	retryErrors: boolean;
 	retryErrorsCount: number;
 	retryErrorsJitter: number;
+	crawlDelay: number;
 };
 
 /**
@@ -254,6 +255,7 @@ export class LinkChecker extends EventEmitter {
 					retryErrors: Boolean(options_.retryErrors),
 					retryErrorsCount: options_.retryErrorsCount ?? 5,
 					retryErrorsJitter: options_.retryErrorsJitter ?? 3000,
+					crawlDelay: options.crawlDelay ?? 0,
 				});
 			})();
 
@@ -360,6 +362,12 @@ export class LinkChecker extends EventEmitter {
 				);
 				return;
 			}
+		}
+
+		// If there is a crawl delay add the delay to the delayChache so that other requests to the same host get delayed
+		if (options.crawlDelay > 0) {
+			const newTimeout = Date.now() + options.crawlDelay * 1000;
+			options.delayCache.set(options.url.host, newTimeout);
 		}
 
 		// Perform a HEAD or GET request based on the need to crawl
@@ -816,6 +824,7 @@ export class LinkChecker extends EventEmitter {
 							retryErrors: options.retryErrors,
 							retryErrorsCount: options.retryErrorsCount,
 							retryErrorsJitter: options.retryErrorsJitter,
+							crawlDelay: options.crawlDelay,
 						});
 					})();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -364,7 +364,7 @@ export class LinkChecker extends EventEmitter {
 			}
 		}
 
-		// If there is a crawl delay add the delay to the delayChache so that other requests to the same host get delayed
+		// If there is a crawl delay add the delay to the delayCache so that other requests to the same host get delayed
 		if (options.crawlDelay > 0) {
 			const newTimeout = Date.now() + options.crawlDelay * 1000;
 			options.delayCache.set(options.url.host, newTimeout);

--- a/src/options.ts
+++ b/src/options.ts
@@ -34,6 +34,7 @@ export type CheckOptions = {
 	checkCss?: boolean;
 	checkFragments?: boolean;
 	statusCodes?: Record<string, StatusCodeAction>;
+	crawlDelay?: number;
 };
 
 export type InternalCheckOptions = {


### PR DESCRIPTION
Closes #534

Adds support for a crawl delay option to control the request rate.

For example, to crawl a page with a delay of 0.5 seconds:
```
linkinator https://your-page.example.com -r --crawl-delay 0.5
```
