### PR TITLE
fix: harden local static server error handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,8 @@ import { startWebServer, stopWebServer } from './server.js';
 import { bufferStream, drainStream, toNodeReadable } from './stream-utils.js';
 import { normalizeBaseUrl } from './url-utils.js';
 
+const STATIC_SERVER_HOST = '127.0.0.1';
+
 export { getConfig } from './config.js';
 
 export enum LinkState {
@@ -197,10 +199,12 @@ export class LinkChecker extends EventEmitter {
 			server = await startWebServer({
 				root: options.serverRoot ?? '',
 				port,
+				host: STATIC_SERVER_HOST,
 				markdown: options.markdown,
 				directoryListing: options.directoryListing,
 				cleanUrls: options.cleanUrls,
 			});
+
 			if (port === undefined) {
 				const addr = server.address() as AddressInfo;
 				port = addr.port;
@@ -211,10 +215,11 @@ export class LinkChecker extends EventEmitter {
 					options.path[i] = options.path[i].slice(1);
 				}
 
-				options.path[i] = `http://localhost:${port}/${options.path[i]}`;
+				options.path[i] =
+					`http://${STATIC_SERVER_HOST}:${port}/${options.path[i]}`;
 			}
 
-			options.staticHttpServerHost = `http://localhost:${port}/`;
+			options.staticHttpServerHost = `http://${STATIC_SERVER_HOST}:${port}/`;
 		}
 
 		if (process.env.LINKINATOR_DEBUG) {
@@ -1073,7 +1078,7 @@ function isCss(response: HttpResponse): boolean {
  * When running a local static web server for the user, translate paths from
  * the Url generated back to something closer to a local filesystem path.
  * @example
- *    http://localhost:0000/test/route/README.md => test/route/README.md
+ *    http://127.0.0.1:0000/test/route/README.md => test/route/README.md
  * @param url The url that was checked
  * @param options Original CheckOptions passed into the client
  */
@@ -1087,7 +1092,7 @@ function mapUrl<T extends string | undefined>(
 
 	let newUrl = url as string;
 
-	// Trim the starting http://localhost:0000 if we stood up a local static server
+	// Trim the starting http://127.0.0.1:0000 if we stood up a local static server
 	if (
 		options?.staticHttpServerHost?.length &&
 		url?.startsWith(options.staticHttpServerHost)

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,6 +16,8 @@ export type WebServerOptions = {
 	root: string;
 	// The port on which to start the local web server
 	port?: number;
+	// The host on which to start the local web server
+	host?: string;
 	// If markdown should be automatically compiled and served
 	markdown?: boolean;
 	// Should directories automatically serve an inde page
@@ -31,19 +33,20 @@ export type WebServerOptions = {
  */
 export async function startWebServer(options: WebServerOptions) {
 	const root = path.resolve(options.root);
+	const host = options.host ?? '127.0.0.1';
 	return new Promise<http.Server>((resolve, reject) => {
 		const server = http
 			.createServer(async (request, response) =>
 				handleRequest(request, response, root, options),
 			)
-			.listen(options.port || 0, () => {
+			.listen(options.port || 0, host, () => {
+				if (!options.port) {
+					const addr = server.address() as AddressInfo;
+					options.port = addr.port;
+				}
 				resolve(server);
 			})
 			.on('error', reject);
-		if (!options.port) {
-			const addr = server.address() as AddressInfo;
-			options.port = addr.port;
-		}
 	});
 }
 
@@ -111,8 +114,7 @@ async function handleRequest(
 			response.end(document);
 			return;
 		}
-	} catch (error) {
-		const error_ = error as Error;
+	} catch {
 		// Try clean URLs: if file not found and cleanUrls is enabled, try adding .html
 		if (options.cleanUrls && !localPath.endsWith('.html')) {
 			try {
@@ -134,10 +136,10 @@ async function handleRequest(
 			} catch {
 				// Fall through to normal 404 handling
 			}
-		}
-		if (!maybeListing) {
-			return404(response, error_);
-			return;
+			if (!maybeListing) {
+				return404(response);
+				return;
+			}
 		}
 	}
 
@@ -166,7 +168,7 @@ async function handleRequest(
 		response.setHeader('Content-Length', Buffer.byteLength(data));
 		response.writeHead(200);
 		response.end(data);
-	} catch (error) {
+	} catch {
 		if (maybeListing) {
 			try {
 				const files = await fs.readdir(originalPath);
@@ -177,18 +179,18 @@ async function handleRequest(
 				const data = `<html><body><ul>${fileList}</ul></body></html>`;
 				response.writeHead(200);
 				response.end(data);
-			} catch (error_) {
-				const error__ = error_ as Error;
-				return404(response, error__);
+			} catch {
+				return404(response);
 			}
 		} else {
-			const error_ = error as Error;
-			return404(response, error_);
+			return404(response);
 		}
 	}
 }
 
-function return404(response: http.ServerResponse, error: Error) {
-	response.writeHead(404);
-	response.end(JSON.stringify(error));
+function return404(response: http.ServerResponse) {
+	response.writeHead(404, {
+		'Content-Type': 'text/plain; charset=UTF-8',
+	});
+	response.end('Not Found');
 }

--- a/test/test.server.ts
+++ b/test/test.server.ts
@@ -16,7 +16,7 @@ describe('server', () => {
 			root: 'test/fixtures/server',
 		});
 		const addr = server.address() as AddressInfo;
-		rootUrl = `http://localhost:${addr.port}`;
+		rootUrl = `http://127.0.0.1:${addr.port}`;
 	});
 	afterAll(async () => {
 		await stopWebServer(server);
@@ -57,12 +57,30 @@ describe('server', () => {
 		const url = `${rootUrl}/../../etc/passwd`;
 		const response = await undiciFetch(url);
 		assert.strictEqual(response.status, 404);
+		assert.strictEqual(await response.text(), 'Not Found');
 	});
 
 	it('should return a 404 for missing paths', async () => {
 		const url = `${rootUrl}/does/not/exist`;
 		const response = await undiciFetch(url);
 		assert.strictEqual(response.status, 404);
+		assert.strictEqual(await response.text(), 'Not Found');
+	});
+
+	it('should not leak filesystem details in 404 responses', async () => {
+		const url = `${rootUrl}/does/not/exist`;
+		const response = await undiciFetch(url);
+		const data = await response.text();
+		assert.strictEqual(response.status, 404);
+		assert.strictEqual(data, 'Not Found');
+		assert.ok(!data.includes('ENOENT'));
+		assert.ok(!data.includes('does/not/exist'));
+		assert.ok(!data.includes('test/fixtures/server'));
+	});
+
+	it('should bind the temporary server to loopback only', () => {
+		const addr = server.address() as AddressInfo;
+		assert.strictEqual(addr.address, '127.0.0.1');
 	});
 
 	it('should work with directories with a .', async () => {
@@ -110,7 +128,7 @@ describe('server with cleanUrls', () => {
 			cleanUrls: true,
 		});
 		const addr = server.address() as AddressInfo;
-		rootUrl = `http://localhost:${addr.port}`;
+		rootUrl = `http://127.0.0.1:${addr.port}`;
 	});
 
 	afterAll(async () => {
@@ -184,7 +202,7 @@ describe('server without cleanUrls', () => {
 			cleanUrls: false,
 		});
 		const addr = server.address() as AddressInfo;
-		rootUrl = `http://localhost:${addr.port}`;
+		rootUrl = `http://127.0.0.1:${addr.port}`;
 	});
 
 	afterAll(async () => {


### PR DESCRIPTION
## Summary
- stop echoing filesystem error details in local static server 404 responses
- bind the temporary local file server to loopback-only and use a consistent synthetic host
- add regression tests for generic 404 bodies and loopback binding

## Why
This addresses the CodeQL alert for code scanning issue 16. The underlying problem was that the temporary local static server could return serialized filesystem errors, which may leak local path information to clients.

## Verification
- npm run build
- npm test