### PR TITLE
fix: apply skip rules across redirects

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,8 @@ export type HttpResponse = {
 	url?: string;
 };
 
+type RequestResponse = HttpResponse & { redirectSkipped?: string };
+
 export type LinkResult = {
 	url: string;
 	status?: number;
@@ -299,53 +301,9 @@ export class LinkChecker extends EventEmitter {
 			}
 		}
 
-		// Explicitly skip non-http[s] links before making the request
-		const proto = options.url.protocol;
-		if (proto !== 'http:' && proto !== 'https:') {
-			const r: LinkResult = {
-				url: mapUrl(options.url.href, options.checkOptions),
-				status: 0,
-				state: LinkState.SKIPPED,
-				parent: mapUrl(options.parent, options.checkOptions),
-			};
-			options.results.push(r);
-			this.emit('link', r);
+		if (await this.shouldSkipUrl(options.url.href, options.checkOptions)) {
+			this.recordSkippedResult(options);
 			return;
-		}
-
-		// Check for a user-configured function to filter out links
-		if (
-			typeof options.checkOptions.linksToSkip === 'function' &&
-			(await options.checkOptions.linksToSkip(options.url.href))
-		) {
-			const result: LinkResult = {
-				url: mapUrl(options.url.href, options.checkOptions),
-				state: LinkState.SKIPPED,
-				parent: options.parent,
-			};
-			options.results.push(result);
-			this.emit('link', result);
-			return;
-		}
-
-		// Check for a user-configured array of link regular expressions that should be skipped
-		if (Array.isArray(options.checkOptions.linksToSkip)) {
-			const skips = options.checkOptions.linksToSkip
-				.map((linkToSkip) => {
-					return new RegExp(linkToSkip).test(options.url.href);
-				})
-				.filter(Boolean);
-
-			if (skips.length > 0) {
-				const result: LinkResult = {
-					url: mapUrl(options.url.href, options.checkOptions),
-					state: LinkState.SKIPPED,
-					parent: mapUrl(options.parent, options.checkOptions),
-				};
-				options.results.push(result);
-				this.emit('link', result);
-				return;
-			}
 		}
 
 		// Check if this host has been marked for delay due to 429
@@ -371,35 +329,43 @@ export class LinkChecker extends EventEmitter {
 		let status = 0;
 		let state = LinkState.BROKEN;
 		let shouldRecurse = false;
-		let response: HttpResponse | undefined;
+		let response: RequestResponse | undefined;
 		const failures: Array<Error | HttpResponse> = [];
 		const originalUrl = options.url.href;
 		const redirectMode =
 			options.checkOptions.redirects === 'error' ? 'manual' : 'follow';
+		const requestOptions = {
+			headers: options.checkOptions.headers,
+			timeout: options.checkOptions.timeout,
+			redirect: redirectMode,
+			allowInsecureCerts: options.checkOptions.allowInsecureCerts,
+			shouldSkipRedirect:
+				redirectMode === 'follow' && this.hasSkipRules(options.checkOptions)
+					? (url: string) => this.shouldSkipUrl(url, options.checkOptions)
+					: undefined,
+		} as const;
 
 		try {
 			response = await makeRequest(
 				options.crawl ? 'GET' : 'HEAD',
 				options.url.href,
-				{
-					headers: options.checkOptions.headers,
-					timeout: options.checkOptions.timeout,
-					redirect: redirectMode,
-					allowInsecureCerts: options.checkOptions.allowInsecureCerts,
-				},
+				requestOptions,
 			);
+			if (response.redirectSkipped) {
+				this.recordSkippedResult(options);
+				return;
+			}
 			if (this.shouldRetryAfter(response, options)) {
 				return;
 			}
 
 			// If we got an HTTP 405, the server may not like HEAD. GET instead!
 			if (response.status === 405) {
-				response = await makeRequest('GET', options.url.href, {
-					headers: options.checkOptions.headers,
-					timeout: options.checkOptions.timeout,
-					redirect: redirectMode,
-					allowInsecureCerts: options.checkOptions.allowInsecureCerts,
-				});
+				response = await makeRequest('GET', options.url.href, requestOptions);
+				if (response.redirectSkipped) {
+					this.recordSkippedResult(options);
+					return;
+				}
 				if (this.shouldRetryAfter(response, options)) {
 					return;
 				}
@@ -420,12 +386,11 @@ export class LinkChecker extends EventEmitter {
 					response.status >= 300) &&
 				!options.crawl
 			) {
-				response = await makeRequest('GET', options.url.href, {
-					headers: options.checkOptions.headers,
-					timeout: options.checkOptions.timeout,
-					redirect: redirectMode,
-					allowInsecureCerts: options.checkOptions.allowInsecureCerts,
-				});
+				response = await makeRequest('GET', options.url.href, requestOptions);
+				if (response.redirectSkipped) {
+					this.recordSkippedResult(options);
+					return;
+				}
 				if (this.shouldRetryAfter(response, options)) {
 					return;
 				}
@@ -453,12 +418,11 @@ export class LinkChecker extends EventEmitter {
 			options.checkOptions.checkCss
 		) {
 			try {
-				response = await makeRequest('GET', options.url.href, {
-					headers: options.checkOptions.headers,
-					timeout: options.checkOptions.timeout,
-					redirect: redirectMode,
-					allowInsecureCerts: options.checkOptions.allowInsecureCerts,
-				});
+				response = await makeRequest('GET', options.url.href, requestOptions);
+				if (response.redirectSkipped) {
+					this.recordSkippedResult(options);
+					return;
+				}
 				if (response !== undefined) {
 					status = response.status;
 				}
@@ -478,12 +442,11 @@ export class LinkChecker extends EventEmitter {
 			const fragmentsToCheck = this.fragmentsToCheck.get(options.url.href);
 			if (fragmentsToCheck && fragmentsToCheck.size > 0) {
 				try {
-					response = await makeRequest('GET', options.url.href, {
-						headers: options.checkOptions.headers,
-						timeout: options.checkOptions.timeout,
-						redirect: redirectMode,
-						allowInsecureCerts: options.checkOptions.allowInsecureCerts,
-					});
+					response = await makeRequest('GET', options.url.href, requestOptions);
+					if (response.redirectSkipped) {
+						this.recordSkippedResult(options);
+						return;
+					}
 					if (response !== undefined) {
 						status = response.status;
 					}
@@ -918,6 +881,48 @@ export class LinkChecker extends EventEmitter {
 		await drainStream(response?.body);
 	}
 
+	private hasSkipRules(checkOptions: InternalCheckOptions): boolean {
+		return (
+			typeof checkOptions.linksToSkip === 'function' ||
+			(Array.isArray(checkOptions.linksToSkip) &&
+				checkOptions.linksToSkip.length > 0)
+		);
+	}
+
+	private async shouldSkipUrl(
+		href: string,
+		checkOptions: InternalCheckOptions,
+	): Promise<boolean> {
+		const url = new URL(href);
+		if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+			return true;
+		}
+
+		if (typeof checkOptions.linksToSkip === 'function') {
+			return checkOptions.linksToSkip(href);
+		}
+
+		return Boolean(
+			checkOptions.linksToSkip?.some((linkToSkip) =>
+				new RegExp(linkToSkip).test(href),
+			),
+		);
+	}
+
+	private recordSkippedResult(options: CrawlOptions): void {
+		const result: LinkResult = {
+			url: mapUrl(options.url.href, options.checkOptions),
+			status:
+				options.url.protocol === 'http:' || options.url.protocol === 'https:'
+					? undefined
+					: 0,
+			state: LinkState.SKIPPED,
+			parent: mapUrl(options.parent, options.checkOptions),
+		};
+		options.results.push(result);
+		this.emit('link', result);
+	}
+
 	/**
 	 * Parse the retry-after header value into a timestamp.
 	 * Supports standard formats (seconds, HTTP date) and non-standard formats (30s, 1m30s).
@@ -1127,8 +1132,9 @@ async function makeRequest(
 		timeout?: number;
 		redirect?: 'follow' | 'manual';
 		allowInsecureCerts?: boolean;
+		shouldSkipRedirect?: (url: string) => Promise<boolean>;
 	} = {},
-): Promise<HttpResponse> {
+): Promise<RequestResponse> {
 	// Build browser-like headers to avoid bot detection
 	const defaultHeaders: Record<string, string> = {
 		Accept:
@@ -1144,54 +1150,100 @@ async function makeRequest(
 		'User-Agent': 'node',
 	};
 
-	const requestOptions: RequestInit = {
-		method,
-		headers: { ...defaultHeaders, ...options.headers },
-		redirect: options.redirect ?? 'follow',
-	};
+	let currentUrl = url;
+	let currentHeaders = { ...defaultHeaders, ...options.headers };
+	const manuallyFollow = Boolean(options.shouldSkipRedirect);
+	const signal = options.timeout
+		? AbortSignal.timeout(options.timeout)
+		: undefined;
 
-	if (options.timeout) {
-		requestOptions.signal = AbortSignal.timeout(options.timeout);
-	}
+	for (let redirectCount = 0; ; redirectCount++) {
+		const requestOptions: RequestInit = {
+			method,
+			headers: currentHeaders,
+			redirect: manuallyFollow ? 'manual' : (options.redirect ?? 'follow'),
+		};
 
-	// For normal requests, use undici fetch so tests and callers can control
-	// request dispatching with undici.setGlobalDispatcher across Node versions.
-	//
-	// For insecure cert requests, we must use undiciFetch with a custom
-	// dispatcher because the global dispatcher doesn't support disabling
-	// certificate validation. We use a shared agent to prevent port exhaustion
-	// from creating new agents per request (which was the original bug).
-	//
-	// For proxy requests, Node's native fetch does not automatically read
-	// http_proxy / https_proxy environment variables, so we must explicitly
-	// create a ProxyAgent dispatcher when those env vars are present.
-	const proxyUrl = getProxyUrl();
-	const response = options.allowInsecureCerts
-		? await undiciFetch(url, {
-				...requestOptions,
-				dispatcher: getSharedAgent(true),
-			})
-		: proxyUrl
-			? await undiciFetch(url, {
+		if (signal) {
+			requestOptions.signal = signal;
+		}
+
+		// For normal requests, use undici fetch so tests and callers can control
+		// request dispatching with undici.setGlobalDispatcher across Node versions.
+		// Custom agents are shared to preserve connection pooling.
+		const proxyUrl = getProxyUrl();
+		const response = options.allowInsecureCerts
+			? await undiciFetch(currentUrl, {
 					...requestOptions,
-					dispatcher: getSharedProxyAgent(proxyUrl),
+					dispatcher: getSharedAgent(true),
 				})
-			: await undiciFetch(url, requestOptions);
+			: proxyUrl
+				? await undiciFetch(currentUrl, {
+						...requestOptions,
+						dispatcher: getSharedProxyAgent(proxyUrl),
+					})
+				: await undiciFetch(currentUrl, requestOptions);
 
-	// Convert headers to a plain object
-	const headers: Record<string, string> = {};
-	response.headers.forEach((value: string, key: string) => {
-		headers[key] = value;
-	});
+		const headers: Record<string, string> = {};
+		response.headers.forEach((value: string, key: string) => {
+			headers[key] = value;
+		});
 
-	const status = response.status;
+		const result: HttpResponse = {
+			status: response.status,
+			headers,
+			body: (response.body ?? undefined) as ReadableStream | undefined,
+			url: response.url,
+		};
 
-	return {
-		status,
-		headers,
-		body: (response.body ?? undefined) as ReadableStream | undefined,
-		url: response.url,
-	};
+		const location = headers.location;
+		if (
+			!manuallyFollow ||
+			!isFetchRedirectStatus(response.status) ||
+			!location
+		) {
+			return result;
+		}
+
+		const targetUrl = new URL(location, currentUrl).href;
+		if (await options.shouldSkipRedirect?.(targetUrl)) {
+			await drainStream(result.body);
+			return { ...result, body: undefined, redirectSkipped: targetUrl };
+		}
+
+		if (redirectCount >= 20) {
+			await drainStream(result.body);
+			throw new TypeError('redirect count exceeded');
+		}
+
+		const currentOrigin = new URL(currentUrl).origin;
+		const targetOrigin = new URL(targetUrl).origin;
+		if (currentOrigin !== targetOrigin) {
+			currentHeaders = stripSensitiveHeaders(currentHeaders);
+		}
+
+		await drainStream(result.body);
+		currentUrl = targetUrl;
+	}
+}
+
+function isFetchRedirectStatus(status: number): boolean {
+	return [301, 302, 303, 307, 308].includes(status);
+}
+
+function stripSensitiveHeaders(
+	headers: Record<string, string>,
+): Record<string, string> {
+	const sensitiveHeaders = new Set([
+		'authorization',
+		'cookie',
+		'proxy-authorization',
+	]);
+	return Object.fromEntries(
+		Object.entries(headers).filter(
+			([name]) => !sensitiveHeaders.has(name.toLowerCase()),
+		),
+	);
 }
 
 /**

--- a/test/test.redirects.ts
+++ b/test/test.redirects.ts
@@ -395,4 +395,322 @@ describe('redirects', () => {
 			assert.ok(redirectWarnings[0].targetUrl?.includes('/target'));
 		});
 	});
+
+	describe('skip rules', () => {
+		it('does not request a skipped redirect target', async () => {
+			let targetRequests = 0;
+			const targetServer = http.createServer((_req, res) => {
+				targetRequests++;
+				res.end('unexpected');
+			});
+			await new Promise<void>((resolve) => targetServer.listen(0, resolve));
+			const targetAddress = targetServer.address() as AddressInfo;
+			const targetUrl = `http://localhost:${targetAddress.port}/external`;
+
+			const redirectServer = http.createServer((_req, res) => {
+				res.writeHead(302, { Location: targetUrl });
+				res.end();
+			});
+			await new Promise<void>((resolve) => redirectServer.listen(0, resolve));
+			const redirectAddress = redirectServer.address() as AddressInfo;
+			const redirectUrl = `http://localhost:${redirectAddress.port}/redirect`;
+
+			try {
+				const results = await check({
+					path: redirectUrl,
+					linksToSkip: [`^${targetUrl}`],
+				});
+				assert.ok(results.passed);
+				assert.strictEqual(results.links[0].state, LinkState.SKIPPED);
+				assert.strictEqual(results.links[0].url, redirectUrl);
+				assert.strictEqual(targetRequests, 0);
+			} finally {
+				redirectServer.close();
+				targetServer.close();
+			}
+		});
+
+		it('checks every target in a redirect chain with function rules', async () => {
+			let skippedTargetRequests = 0;
+			const chainServer = http.createServer((req, res) => {
+				if (req.url === '/start') {
+					res.writeHead(302, { Location: '/middle' });
+					res.end();
+					return;
+				}
+				if (req.url === '/middle') {
+					res.writeHead(307, { Location: '/skipped' });
+					res.end();
+					return;
+				}
+				skippedTargetRequests++;
+				res.end('unexpected');
+			});
+			await new Promise<void>((resolve) => chainServer.listen(0, resolve));
+			const address = chainServer.address() as AddressInfo;
+			const chainUrl = `http://localhost:${address.port}`;
+
+			try {
+				const results = await check({
+					path: `${chainUrl}/start`,
+					linksToSkip: async (url) => url === `${chainUrl}/skipped`,
+				});
+				assert.strictEqual(results.links[0].state, LinkState.SKIPPED);
+				assert.strictEqual(skippedTargetRequests, 0);
+			} finally {
+				chainServer.close();
+			}
+		});
+
+		it('does not forward sensitive headers across origins', async () => {
+			let receivedAuthorization: string | undefined;
+			let receivedCookie: string | undefined;
+			let receivedCustomHeader: string | undefined;
+			const targetServer = http.createServer((req, res) => {
+				receivedAuthorization = req.headers.authorization;
+				receivedCookie = req.headers.cookie;
+				receivedCustomHeader = req.headers['x-linkinator-test'] as string;
+				res.writeHead(200, { 'Content-Type': 'text/html' });
+				res.end('ok');
+			});
+			await new Promise<void>((resolve) => targetServer.listen(0, resolve));
+			const targetAddress = targetServer.address() as AddressInfo;
+			const targetUrl = `http://localhost:${targetAddress.port}/target`;
+
+			const redirectServer = http.createServer((_req, res) => {
+				res.writeHead(302, { Location: targetUrl });
+				res.end();
+			});
+			await new Promise<void>((resolve) => redirectServer.listen(0, resolve));
+			const redirectAddress = redirectServer.address() as AddressInfo;
+			const redirectUrl = `http://localhost:${redirectAddress.port}/redirect`;
+
+			try {
+				const results = await check({
+					path: redirectUrl,
+					linksToSkip: ['never-match'],
+					headers: {
+						Authorization: 'Bearer secret',
+						Cookie: 'session=secret',
+						'X-Linkinator-Test': 'preserved',
+					},
+				});
+				assert.ok(results.passed);
+				assert.strictEqual(results.links[0].url, redirectUrl);
+				assert.strictEqual(receivedAuthorization, undefined);
+				assert.strictEqual(receivedCookie, undefined);
+				assert.strictEqual(receivedCustomHeader, 'preserved');
+			} finally {
+				redirectServer.close();
+				targetServer.close();
+			}
+		});
+
+		it('preserves sensitive headers for same-origin redirects', async () => {
+			let receivedAuthorization: string | undefined;
+			const sameOriginServer = http.createServer((req, res) => {
+				if (req.url === '/redirect') {
+					res.writeHead(302, { Location: '/target' });
+					res.end();
+					return;
+				}
+				receivedAuthorization = req.headers.authorization;
+				res.writeHead(200, { 'Content-Type': 'text/html' });
+				res.end('ok');
+			});
+			await new Promise<void>((resolve) => sameOriginServer.listen(0, resolve));
+			const address = sameOriginServer.address() as AddressInfo;
+			const redirectUrl = `http://localhost:${address.port}/redirect`;
+
+			try {
+				const results = await check({
+					path: redirectUrl,
+					linksToSkip: ['never-match'],
+					headers: { Authorization: 'Bearer same-origin' },
+				});
+				assert.ok(results.passed);
+				assert.strictEqual(receivedAuthorization, 'Bearer same-origin');
+			} finally {
+				sameOriginServer.close();
+			}
+		});
+
+		it('does not follow non-redirect 3xx statuses with Location headers', async () => {
+			let targetRequests = 0;
+			const statusServer = http.createServer((req, res) => {
+				if (req.url === '/not-modified') {
+					res.writeHead(304, { Location: '/target' });
+					res.end();
+					return;
+				}
+				targetRequests++;
+				res.end('unexpected');
+			});
+			await new Promise<void>((resolve) => statusServer.listen(0, resolve));
+			const address = statusServer.address() as AddressInfo;
+
+			try {
+				const results = await check({
+					path: `http://localhost:${address.port}/not-modified`,
+					linksToSkip: ['never-match'],
+				});
+				assert.ok(!results.passed);
+				assert.strictEqual(results.links[0].status, 304);
+				assert.strictEqual(targetRequests, 0);
+			} finally {
+				statusServer.close();
+			}
+		});
+
+		it('keeps redirects in error mode broken without applying target skips', async () => {
+			let targetRequests = 0;
+			const errorModeServer = http.createServer((req, res) => {
+				if (req.url === '/redirect') {
+					res.writeHead(302, { Location: '/target' });
+					res.end();
+					return;
+				}
+				targetRequests++;
+				res.end('unexpected');
+			});
+			await new Promise<void>((resolve) => errorModeServer.listen(0, resolve));
+			const address = errorModeServer.address() as AddressInfo;
+			const serverUrl = `http://localhost:${address.port}`;
+
+			try {
+				const results = await check({
+					path: `${serverUrl}/redirect`,
+					linksToSkip: [`${serverUrl}/target`],
+					redirects: 'error',
+				});
+				assert.ok(!results.passed);
+				assert.strictEqual(results.links[0].state, LinkState.BROKEN);
+				assert.strictEqual(results.links[0].status, 302);
+				assert.strictEqual(targetRequests, 0);
+			} finally {
+				errorModeServer.close();
+			}
+		});
+
+		it('fails redirect chains that exceed the fetch redirect limit', async () => {
+			let requests = 0;
+			const loopServer = http.createServer((req, res) => {
+				requests++;
+				const current = Number(
+					new URL(req.url || '/', 'http://localhost').searchParams.get('n'),
+				);
+				res.writeHead(302, { Location: `/loop?n=${current + 1}` });
+				res.end();
+			});
+			await new Promise<void>((resolve) => loopServer.listen(0, resolve));
+			const address = loopServer.address() as AddressInfo;
+			const loopUrl = `http://localhost:${address.port}/loop?n=0`;
+
+			try {
+				const results = await check({
+					path: loopUrl,
+					linksToSkip: ['never-match'],
+				});
+				assert.ok(!results.passed);
+				assert.strictEqual(results.links[0].state, LinkState.BROKEN);
+				// One initial request plus the maximum 20 followed redirects.
+				assert.strictEqual(requests, 21);
+			} finally {
+				loopServer.close();
+			}
+		});
+
+		it('allows exactly the fetch limit of 20 redirects', async () => {
+			let requests = 0;
+			const limitServer = http.createServer((req, res) => {
+				requests++;
+				const current = Number(
+					new URL(req.url || '/', 'http://localhost').searchParams.get('n'),
+				);
+				if (current < 20) {
+					res.writeHead(302, { Location: `/chain?n=${current + 1}` });
+					res.end();
+					return;
+				}
+				res.writeHead(200, { 'Content-Type': 'text/html' });
+				res.end('ok');
+			});
+			await new Promise<void>((resolve) => limitServer.listen(0, resolve));
+			const address = limitServer.address() as AddressInfo;
+			const limitUrl = `http://localhost:${address.port}/chain?n=0`;
+
+			try {
+				const results = await check({
+					path: limitUrl,
+					linksToSkip: ['never-match'],
+				});
+				assert.ok(results.passed);
+				assert.strictEqual(results.links[0].status, 200);
+				assert.strictEqual(requests, 21);
+			} finally {
+				limitServer.close();
+			}
+		});
+
+		it('reports a failed redirect target as broken', async () => {
+			const redirectServer = http.createServer((_req, res) => {
+				res.writeHead(302, { Location: 'http://localhost:1/unreachable' });
+				res.end();
+			});
+			await new Promise<void>((resolve) => redirectServer.listen(0, resolve));
+			const address = redirectServer.address() as AddressInfo;
+			const redirectUrl = `http://localhost:${address.port}/redirect`;
+
+			try {
+				const results = await check({
+					path: redirectUrl,
+					linksToSkip: ['never-match'],
+				});
+				assert.ok(!results.passed);
+				assert.strictEqual(results.links[0].state, LinkState.BROKEN);
+				assert.strictEqual(results.links[0].url, redirectUrl);
+			} finally {
+				redirectServer.close();
+			}
+		});
+
+		it('applies retry handling to the final redirect response', async () => {
+			let targetRequests = 0;
+			const targetServer = http.createServer((_req, res) => {
+				targetRequests++;
+				if (targetRequests === 1) {
+					res.writeHead(429, { 'Retry-After': '0' });
+					res.end();
+					return;
+				}
+				res.writeHead(200, { 'Content-Type': 'text/html' });
+				res.end('ok');
+			});
+			await new Promise<void>((resolve) => targetServer.listen(0, resolve));
+			const targetAddress = targetServer.address() as AddressInfo;
+			const targetUrl = `http://localhost:${targetAddress.port}/target`;
+
+			const redirectServer = http.createServer((_req, res) => {
+				res.writeHead(302, { Location: targetUrl });
+				res.end();
+			});
+			await new Promise<void>((resolve) => redirectServer.listen(0, resolve));
+			const redirectAddress = redirectServer.address() as AddressInfo;
+			const redirectUrl = `http://localhost:${redirectAddress.port}/redirect`;
+
+			try {
+				const results = await check({
+					path: redirectUrl,
+					linksToSkip: ['never-match'],
+					retry: true,
+				});
+				assert.ok(results.passed);
+				assert.strictEqual(results.links[0].status, 200);
+				assert.strictEqual(targetRequests, 2);
+			} finally {
+				redirectServer.close();
+				targetServer.close();
+			}
+		});
+	});
 });


### PR DESCRIPTION
## Summary

- inspect every standard HTTP redirect target against `linksToSkip` before requesting it
- keep manual redirect handling inside the existing request pipeline so failures, retries, timeouts, and result URLs retain their current behavior
- strip sensitive credentials when a redirect crosses origins while preserving same-origin credentials and non-sensitive headers
- preserve Fetch-compatible redirect statuses and the 20-redirect limit

## Background

Fixes #827.

This replaces and supersedes #835. That PR identified the right underlying problem and supplied the initial regression coverage, but manual redirect handling outside the normal request lifecycle introduced credential forwarding, unhandled target failures, retry bypasses, result URL changes, and redirect-limit differences. This implementation addresses the same issue while preserving the established request semantics.

Thank you @mcdurdin for the detailed report and reproduction in #827, and thank you @alejosworkstuff for investigating the issue, proposing #835, and moving the fix forward. The analysis and tests there were valuable in shaping this version.

## Validation

- `npm test` — 248 tests passed across 15 files
- `npm run coverage` — 247 tests passed at the time of the coverage run; 93.77% statements, 88.11% branches, 96.9% functions
- `npm run build`
- `npm run lint`
- `git diff --check`

The redirect suite covers direct and multi-hop skips, regex and async-function rules, relative locations, cross-origin credential stripping, same-origin credential preservation, non-sensitive header preservation, unreachable targets, final-response retries, original result identity, `redirects: error`, non-followable 3xx statuses, and both sides of the 20-hop redirect boundary.
