### PR TITLE
fix: enforce crawl concurrency limit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -165,6 +165,29 @@ export class LinkChecker extends EventEmitter {
 	// Track which fragments need to be checked for each URL
 	private fragmentsToCheck = new Map<string, Set<string>>();
 
+	/**
+	 * Register a crawl as pending, then start it only after the queue grants a
+	 * concurrency slot. The separate completion promise lets duplicate links
+	 * wait for the original check without starting that check eagerly.
+	 */
+	private enqueueCrawl(options: CrawlOptions): Promise<void> {
+		let resolveCompletion: () => void;
+		const completion = new Promise<void>((resolve) => {
+			resolveCompletion = resolve;
+		});
+
+		options.pendingChecks.set(options.url.href, completion);
+		options.queue.add(async () => {
+			try {
+				await this.crawl(options);
+			} finally {
+				resolveCompletion();
+			}
+		});
+
+		return completion;
+	}
+
 	on(event: 'link', listener: (result: LinkResult) => void): this;
 	on(event: 'pagestart', listener: (link: string) => void): this;
 	on(event: 'retry', listener: (details: RetryInfo) => void): this;
@@ -243,32 +266,23 @@ export class LinkChecker extends EventEmitter {
 			const url = new URL(path);
 			initCache.add(url.href);
 
-			// Create a promise for this starting page so other pages can wait for it
-			const crawlPromise = (async () => {
-				await this.crawl({
-					url,
-					crawl: true,
-					checkOptions: options,
-					results,
-					cache: initCache,
-					relationshipCache,
-					pendingChecks,
-					delayCache,
-					retryErrorsCache,
-					queue,
-					rootPath: path,
-					retry: Boolean(options_.retry),
-					retryErrors: Boolean(options_.retryErrors),
-					retryErrorsCount: options_.retryErrorsCount ?? 5,
-					retryErrorsJitter: options_.retryErrorsJitter ?? 3000,
-				});
-			})();
-
-			// Store the promise
-			pendingChecks.set(url.href, crawlPromise);
-
-			// Queue the crawl
-			queue.add(() => crawlPromise);
+			this.enqueueCrawl({
+				url,
+				crawl: true,
+				checkOptions: options,
+				results,
+				cache: initCache,
+				relationshipCache,
+				pendingChecks,
+				delayCache,
+				retryErrorsCache,
+				queue,
+				rootPath: path,
+				retry: Boolean(options_.retry),
+				retryErrors: Boolean(options_.retryErrors),
+				retryErrorsCount: options_.retryErrorsCount ?? 5,
+				retryErrorsJitter: options_.retryErrorsJitter ?? 3000,
+			});
 		}
 
 		await queue.onIdle();
@@ -762,36 +776,27 @@ export class LinkChecker extends EventEmitter {
 					// URL hasn't been checked, add to cache and create a promise for the check
 					options.cache.add(result.url.href);
 
-					// Create a promise that will resolve when the check completes
-					const checkPromise = (async () => {
-						if (result.url === undefined) {
-							throw new Error('url is undefined');
-						}
-						await this.crawl({
-							url: result.url,
-							crawl: crawl ?? false,
-							cache: options.cache,
-							relationshipCache: options.relationshipCache,
-							pendingChecks: options.pendingChecks,
-							delayCache: options.delayCache,
-							retryErrorsCache: options.retryErrorsCache,
-							results: options.results,
-							checkOptions: options.checkOptions,
-							queue: options.queue,
-							parent: options.url.href,
-							rootPath: options.rootPath,
-							retry: options.retry,
-							retryErrors: options.retryErrors,
-							retryErrorsCount: options.retryErrorsCount,
-							retryErrorsJitter: options.retryErrorsJitter,
-						});
-					})();
-
-					// Store the promise so other parents can wait for it
-					options.pendingChecks.set(result.url.href, checkPromise);
-
-					// Queue the check
-					options.queue.add(() => checkPromise);
+					if (result.url === undefined) {
+						throw new Error('url is undefined');
+					}
+					this.enqueueCrawl({
+						url: result.url,
+						crawl: crawl ?? false,
+						cache: options.cache,
+						relationshipCache: options.relationshipCache,
+						pendingChecks: options.pendingChecks,
+						delayCache: options.delayCache,
+						retryErrorsCache: options.retryErrorsCache,
+						results: options.results,
+						checkOptions: options.checkOptions,
+						queue: options.queue,
+						parent: options.url.href,
+						rootPath: options.rootPath,
+						retry: options.retry,
+						retryErrors: options.retryErrors,
+						retryErrorsCount: options.retryErrorsCount,
+						retryErrorsJitter: options.retryErrorsJitter,
+					});
 				} else {
 					// URL is being checked or has been checked
 					// Only report duplicate results for BROKEN links so users can see

--- a/test/fixtures/concurrency/index.html
+++ b/test/fixtures/concurrency/index.html
@@ -1,0 +1,5 @@
+<a href="http://example.invalid/1">one</a>
+<a href="http://example.invalid/2">two</a>
+<a href="http://example.invalid/3">three</a>
+<a href="http://example.invalid/4">four</a>
+<a href="http://example.invalid/5">five</a>

--- a/test/test.concurrency.ts
+++ b/test/test.concurrency.ts
@@ -1,0 +1,58 @@
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, assert, describe, it } from 'vitest';
+import { check } from '../src/index.js';
+
+describe('concurrency', () => {
+	let server: http.Server | undefined;
+
+	afterEach(async () => {
+		if (server) {
+			await new Promise<void>((resolve, reject) => {
+				server?.close((error) => (error ? reject(error) : resolve()));
+			});
+			server = undefined;
+		}
+	});
+
+	it('limits concurrent HTTP requests end to end', async () => {
+		let activeRequests = 0;
+		let maxActiveRequests = 0;
+
+		server = http.createServer(async (request, response) => {
+			activeRequests++;
+			maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
+			try {
+				if (request.url === '/') {
+					response.setHeader('content-type', 'text/html');
+					response.end(
+						Array.from(
+							{ length: 12 },
+							(_, index) => `<a href="/${index + 1}">link</a>`,
+						).join('\n'),
+					);
+					return;
+				}
+
+				await new Promise((resolve) => setTimeout(resolve, 25));
+				response.writeHead(200).end();
+			} finally {
+				activeRequests--;
+			}
+		});
+
+		await new Promise<void>((resolve, reject) => {
+			server?.once('error', reject).listen(0, '127.0.0.1', resolve);
+		});
+		const { port } = server.address() as AddressInfo;
+
+		const results = await check({
+			path: `http://127.0.0.1:${port}/`,
+			concurrency: 3,
+		});
+
+		assert.ok(results.passed);
+		assert.strictEqual(results.links.length, 13);
+		assert.strictEqual(maxActiveRequests, 3);
+	});
+});

--- a/test/test.concurrency.ts
+++ b/test/test.concurrency.ts
@@ -55,4 +55,37 @@ describe('concurrency', () => {
 		assert.strictEqual(results.links.length, 13);
 		assert.strictEqual(maxActiveRequests, 3);
 	});
+
+	it('limits concurrent starting URLs end to end', async () => {
+		let activeRequests = 0;
+		let maxActiveRequests = 0;
+
+		server = http.createServer(async (_request, response) => {
+			activeRequests++;
+			maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
+			try {
+				await new Promise((resolve) => setTimeout(resolve, 25));
+				response.writeHead(200, { 'content-type': 'text/plain' }).end();
+			} finally {
+				activeRequests--;
+			}
+		});
+
+		await new Promise<void>((resolve, reject) => {
+			server?.once('error', reject).listen(0, '127.0.0.1', resolve);
+		});
+		const { port } = server.address() as AddressInfo;
+
+		const results = await check({
+			path: Array.from(
+				{ length: 12 },
+				(_, index) => `http://127.0.0.1:${port}/${index + 1}`,
+			),
+			concurrency: 3,
+		});
+
+		assert.ok(results.passed);
+		assert.strictEqual(results.links.length, 12);
+		assert.strictEqual(maxActiveRequests, 3);
+	});
 });

--- a/test/test.index.ts
+++ b/test/test.index.ts
@@ -71,6 +71,40 @@ describe('linkinator', () => {
 		assert.strictEqual(checkerSpy.mock.calls.length, 2);
 	});
 
+	it('should not start more crawls than the configured concurrency', async () => {
+		const mockPool = mockAgent.get('http://example.invalid');
+		for (let i = 1; i <= 5; i++) {
+			mockPool.intercept({ path: `/${i}`, method: 'HEAD' }).reply(200, '');
+		}
+
+		const checker = new LinkChecker();
+		const crawl = checker.crawl.bind(checker);
+		let activeCrawls = 0;
+		let maxActiveCrawls = 0;
+		vi.spyOn(checker, 'crawl').mockImplementation(async (options) => {
+			activeCrawls++;
+			maxActiveCrawls = Math.max(maxActiveCrawls, activeCrawls);
+			try {
+				await new Promise((resolve) => setTimeout(resolve, 10));
+				await crawl(options);
+			} finally {
+				activeCrawls--;
+			}
+		});
+
+		const results = await checker.check({
+			path: 'test/fixtures/concurrency',
+			concurrency: 2,
+		});
+
+		assert.ok(results.passed);
+		assert.strictEqual(results.links.length, 6);
+		assert.ok(
+			maxActiveCrawls <= 2,
+			`observed ${maxActiveCrawls} active crawls`,
+		);
+	});
+
 	it('should skip links if asked nicely', async () => {
 		const results = await check({
 			path: 'test/fixtures/skip',
@@ -915,6 +949,7 @@ describe('linkinator', () => {
 				'test/fixtures/repeated-broken-link/pageA.html',
 				'test/fixtures/repeated-broken-link/pageB.html',
 			],
+			concurrency: 1,
 		});
 		assert.ok(!results.passed);
 


### PR DESCRIPTION
Fixes JustinBeckwith/linkinator-action#259

## Summary

- defer starting-page and discovered-link crawls until the queue grants a concurrency slot
- preserve pending-check coordination for duplicate links with a separate completion promise
- add scheduling and socket-level regression coverage, including duplicate-link behavior at concurrency 1

## Root cause

Crawl promises were created with immediately invoked async functions before they were passed to the queue. The queue therefore tracked already-running work and could not enforce the configured concurrency limit. Large scans could launch hundreds of requests together, causing valid links to fail with network timeouts.

## Impact

The `concurrency` option now limits actual crawl and HTTP request activity. This prevents request bursts and the resulting false-positive `fetch failed` results on large scans.

## Validation

- `npm run build`
- `npm run lint`
- `npm test -- --run` — 251 tests passed
- `npm run coverage -- --run` — 93.89% statement coverage
- `npm pack --dry-run`
- `npm run build-binaries`
- verified the socket-level regression test fails against the pre-fix source with 12 active requests for a limit of 3, and passes after the fix with exactly 3
