### PR TITLE
fix: match skip rules against URL fragments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -716,6 +716,28 @@ export class LinkChecker extends EventEmitter {
 					continue;
 				}
 
+				// Requests are deduplicated by the fragmentless URL, but skip rules
+				// should see the complete URL as it appeared in the document.
+				if (
+					this.hasSkipRules(options.checkOptions) &&
+					(result.url.protocol === 'http:' ||
+						result.url.protocol === 'https:') &&
+					result.urlWithFragment &&
+					(await this.shouldSkipUrl(
+						result.urlWithFragment,
+						options.checkOptions,
+					))
+				) {
+					const skippedResult: LinkResult = {
+						url: mapUrl(result.urlWithFragment, options.checkOptions),
+						state: LinkState.SKIPPED,
+						parent: mapUrl(options.url.href, options.checkOptions),
+					};
+					options.results.push(skippedResult);
+					this.emit('link', skippedResult);
+					continue;
+				}
+
 				// Track fragments that need validation if checkFragments is enabled
 				if (
 					options.checkOptions.checkFragments &&

--- a/src/links.ts
+++ b/src/links.ts
@@ -44,6 +44,7 @@ export type ParsedUrl = {
 	link: string;
 	error?: Error;
 	url?: URL;
+	urlWithFragment?: string;
 	fragment?: string;
 };
 
@@ -219,11 +220,12 @@ function parseAttribute(name: string, value: string): string[] {
 function parseLink(link: string, baseUrl: string): ParsedUrl {
 	try {
 		const url = new URL(link, baseUrl);
+		const urlWithFragment = url.href;
 		const fragment = url.hash
 			? decodeURIComponent(url.hash.slice(1))
 			: undefined;
 		url.hash = '';
-		return { link, url, fragment };
+		return { link, url, urlWithFragment, fragment };
 	} catch (error) {
 		return { link, error: error as Error };
 	}

--- a/test/fixtures/skip-fragments/index.html
+++ b/test/fixtures/skip-fragments/index.html
@@ -1,0 +1,7 @@
+<html>
+<body>
+<a href="https://github.com/example/project#readme">skip this fragment</a>
+<a href="https://github.com/example/project#L12-L14">skip this line range</a>
+<a href="https://github.com/example/project#overview">check this URL</a>
+</body>
+</html>

--- a/test/test.index.ts
+++ b/test/test.index.ts
@@ -83,6 +83,76 @@ describe('linkinator', () => {
 		);
 	});
 
+	it('should match linksToSkip against URL fragments', async () => {
+		const mockPool = mockAgent.get('https://github.com');
+		mockPool
+			.intercept({ path: '/example/project', method: 'HEAD' })
+			.reply(200, '');
+		const results = await check({
+			path: 'test/fixtures/skip-fragments',
+			linksToSkip: ['.*#(?:readme|L\\d+(?:-L\\d+)?)$'],
+		});
+
+		expect(results.links).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					url: 'https://github.com/example/project#readme',
+					state: LinkState.SKIPPED,
+				}),
+				expect.objectContaining({
+					url: 'https://github.com/example/project#L12-L14',
+					state: LinkState.SKIPPED,
+				}),
+				expect.objectContaining({
+					url: 'https://github.com/example/project',
+					state: LinkState.OK,
+				}),
+			]),
+		);
+		expect(
+			results.links.filter((link) => link.state === LinkState.SKIPPED),
+		).toHaveLength(2);
+	});
+
+	it('should skip an exact URL fragment without fragment validation', async () => {
+		const results = await check({
+			path: 'test/fixtures/skip-fragments',
+			linksToSkip: [
+				'https://github.com/example/project#readme',
+				'https://github.com/example/project#L12-L14',
+				'https://github.com/example/project#overview',
+			],
+			checkFragments: true,
+		});
+
+		expect(results.passed).toBe(true);
+		expect(
+			results.links.filter((link) => link.state === LinkState.SKIPPED),
+		).toHaveLength(3);
+	});
+
+	it('should pass URL fragments to a linksToSkip function', async () => {
+		const linksSeen: string[] = [];
+		const results = await check({
+			path: 'test/fixtures/skip-fragments',
+			linksToSkip: async (link) => {
+				linksSeen.push(link);
+				return link.includes('#');
+			},
+		});
+
+		expect(linksSeen).toEqual(
+			expect.arrayContaining([
+				'https://github.com/example/project#readme',
+				'https://github.com/example/project#L12-L14',
+				'https://github.com/example/project#overview',
+			]),
+		);
+		expect(
+			results.links.filter((link) => link.state === LinkState.SKIPPED),
+		).toHaveLength(3);
+	});
+
 	it('should skip links if passed a linksToSkip function', async () => {
 		const mockPool = mockAgent.get('https://good.com');
 		mockPool.intercept({ path: '/', method: 'HEAD' }).reply(200, '');


### PR DESCRIPTION
## Summary

- preserve the fully resolved URL, including its fragment, for skip-rule matching
- keep fragmentless URLs for request caching and deduplication
- avoid fragment validation for links skipped by fragment-aware rules
- cover exact rules, README and GitHub line-range regexes, callback rules, `checkFragments`, and shared-request deduplication

## Root cause

`parseLink` extracted the hash into `fragment` and cleared `url.hash` so requests could be deduplicated by their base URL. `linksToSkip` was evaluated later against that fragmentless URL, which made patterns ending in fragments impossible to match.

The skip decision now occurs against the preserved complete URL before the fragmentless request URL enters the relationship and request caches. This retains existing request behavior while allowing fragment-specific rules to work.

References JustinBeckwith/linkinator-action#240.

## Validation

- `npm test -- --run test/test.index.ts` (68 tests)
- `npm test -- --run` (251 tests)
- `npm run coverage` (251 tests; 93.81% statements, 88.24% branches, 96.9% functions, 93.71% lines)
- `npm run build`
- `npm run lint`
- `git diff --check`

Biome reports the existing informational schema-version mismatch, but lint passes with no errors.
