### PR TITLE
fix: honor no_proxy environment variables

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import * as path from 'node:path';
 import process from 'node:process';
 import {
 	Agent,
-	ProxyAgent,
+	EnvHttpProxyAgent,
 	type RequestInit,
 	fetch as undiciFetch,
 } from 'undici';
@@ -17,7 +17,7 @@ import { getCssLinks, getLinks, validateFragments } from './links.js';
 let sharedInsecureAgent: Agent | undefined;
 
 // Shared proxy agent, cached per proxy URL to avoid repeated allocations.
-let sharedProxyAgent: ProxyAgent | undefined;
+let sharedProxyAgent: EnvHttpProxyAgent | undefined;
 let cachedProxyUrl: string | undefined;
 
 /**
@@ -43,9 +43,12 @@ function getProxyUrl(): string | undefined {
 	return url || undefined;
 }
 
-function getSharedProxyAgent(proxyUrl: string): ProxyAgent {
+function getSharedProxyAgent(proxyUrl: string): EnvHttpProxyAgent {
 	if (!sharedProxyAgent || cachedProxyUrl !== proxyUrl) {
-		sharedProxyAgent = new ProxyAgent(proxyUrl);
+		sharedProxyAgent = new EnvHttpProxyAgent({
+			httpProxy: proxyUrl,
+			httpsProxy: proxyUrl,
+		});
 		cachedProxyUrl = proxyUrl;
 	}
 	return sharedProxyAgent;

--- a/test/test.proxy.ts
+++ b/test/test.proxy.ts
@@ -13,6 +13,16 @@ describe('proxy', () => {
 
 	beforeEach(async () => {
 		proxiedHosts = [];
+		for (const name of [
+			'http_proxy',
+			'HTTP_PROXY',
+			'https_proxy',
+			'HTTPS_PROXY',
+			'no_proxy',
+			'NO_PROXY',
+		]) {
+			vi.stubEnv(name, undefined);
+		}
 
 		// Target server: serves a simple HTML page with no outbound links
 		targetServer = http.createServer((_req, res) => {
@@ -122,6 +132,34 @@ describe('proxy', () => {
 			proxiedHosts.length,
 			0,
 			'Proxy should not have been contacted when env vars are unset',
+		);
+	});
+
+	it('should honor no_proxy', async () => {
+		vi.stubEnv('http_proxy', proxyUrl);
+		vi.stubEnv('no_proxy', '127.0.0.1');
+
+		const results = await check({ path: targetUrl });
+
+		assert.ok(results.passed);
+		assert.strictEqual(
+			proxiedHosts.length,
+			0,
+			'Proxy should not be contacted for hosts in no_proxy',
+		);
+	});
+
+	it('should honor NO_PROXY', async () => {
+		vi.stubEnv('HTTP_PROXY', proxyUrl);
+		vi.stubEnv('NO_PROXY', '127.0.0.1');
+
+		const results = await check({ path: targetUrl });
+
+		assert.ok(results.passed);
+		assert.strictEqual(
+			proxiedHosts.length,
+			0,
+			'Proxy should not be contacted for hosts in NO_PROXY',
 		);
 	});
 });

--- a/test/test.proxy.ts
+++ b/test/test.proxy.ts
@@ -163,6 +163,19 @@ describe('proxy', () => {
 		);
 	});
 
+	it('should still use the proxy when NO_PROXY does not match', async () => {
+		vi.stubEnv('HTTP_PROXY', proxyUrl);
+		vi.stubEnv('NO_PROXY', 'example.com');
+
+		const results = await check({ path: targetUrl });
+
+		assert.ok(results.passed);
+		assert.ok(
+			proxiedHosts.length > 0,
+			'Non-matching NO_PROXY entries should not disable the proxy',
+		);
+	});
+
 	it('should bypass the proxy for local file scans excluded by NO_PROXY', async () => {
 		vi.stubEnv('HTTP_PROXY', proxyUrl);
 		vi.stubEnv('NO_PROXY', '127.0.0.1');

--- a/test/test.proxy.ts
+++ b/test/test.proxy.ts
@@ -162,4 +162,21 @@ describe('proxy', () => {
 			'Proxy should not be contacted for hosts in NO_PROXY',
 		);
 	});
+
+	it('should bypass the proxy for local file scans excluded by NO_PROXY', async () => {
+		vi.stubEnv('HTTP_PROXY', proxyUrl);
+		vi.stubEnv('NO_PROXY', '127.0.0.1');
+
+		const results = await check({
+			path: 'test/fixtures/local',
+			recurse: true,
+		});
+
+		assert.ok(results.passed);
+		assert.strictEqual(
+			proxiedHosts.length,
+			0,
+			'The internal static server should not be contacted through the proxy',
+		);
+	});
 });


### PR DESCRIPTION
## Summary

- use Undici's `EnvHttpProxyAgent` for environment-configured proxies
- preserve Linkinator's existing proxy precedence for HTTP and HTTPS requests
- honor both lowercase `no_proxy` and uppercase `NO_PROXY`
- isolate proxy environment variables in the proxy test suite

## Root cause

Linkinator selected `ProxyAgent` whenever any proxy environment variable was present. `ProxyAgent` does not evaluate `NO_PROXY`, so even explicitly excluded hosts—including Linkinator's internal `127.0.0.1` static server—were sent through the proxy.

This caused local file and Markdown scans to fail in proxied environments when the proxy could not reach the loopback server.

## Impact

Hosts matched by `no_proxy` or `NO_PROXY` now connect directly. Other requests continue to use the configured proxy with the existing precedence behavior.

## Validation

- `npx vitest run test/test.proxy.ts` — 9 passed
- `npm test -- --run` — 258 passed
- `npm run build`
- `npm run lint`
- `npm pack --dry-run`
