### PR TITLE
fix retry error count

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1043,21 +1043,18 @@ export class LinkChecker extends EventEmitter {
 			return false;
 		}
 
-		// Check to see if there is already a request to wait for this URL:
-		let currentRetries = 1;
-		const cachedRetries = options.retryErrorsCache.get(options.url.href);
-		if (cachedRetries !== undefined) {
-			// Use whichever time is higher in the cache
-			currentRetries = cachedRetries;
-			if (currentRetries > maxRetries) return false;
-			options.retryErrorsCache.set(options.url.href, currentRetries + 1);
-		} else {
-			options.retryErrorsCache.set(options.url.href, 1);
+		const retriesScheduled =
+			options.retryErrorsCache.get(options.url.href) ?? 0;
+		if (retriesScheduled >= maxRetries) {
+			return false;
 		}
+
+		const currentRetry = retriesScheduled + 1;
+		options.retryErrorsCache.set(options.url.href, currentRetry);
 
 		// Use exponential backoff algorithm to take pressure off upstream service:
 		const retryAfter =
-			2 ** currentRetries * 1000 + Math.random() * options.retryErrorsJitter;
+			2 ** currentRetry * 1000 + Math.random() * options.retryErrorsJitter;
 
 		options.queue.add(
 			async () => {

--- a/test/test.retry.ts
+++ b/test/test.retry.ts
@@ -231,6 +231,40 @@ describe('retries', () => {
 	}
 
 	describe('retry-errors', () => {
+		it.each([
+			{ retryErrorsCount: 0, expectedRetries: 0 },
+			{ retryErrorsCount: 1, expectedRetries: 1 },
+			{ retryErrorsCount: 2, expectedRetries: 2 },
+			{ retryErrorsCount: 5, expectedRetries: 5 },
+		])('retries exactly $expectedRetries times when retryErrorsCount is $retryErrorsCount', async ({
+			retryErrorsCount,
+			expectedRetries,
+		}) => {
+			const mockPool = mockAgent.get('http://example.invalid');
+			mockPool
+				.intercept({ path: '/', method: 'GET' })
+				.reply(503, '')
+				.times(expectedRetries + 1);
+
+			let retryEvents = 0;
+			const checker = new LinkChecker().on('retry', () => {
+				retryEvents++;
+			});
+			const clock = vi.useFakeTimers({ shouldAdvanceTime: true });
+			const checkPromise = checker.check({
+				path: 'http://example.invalid/',
+				retryErrors: true,
+				retryErrorsCount,
+				retryErrorsJitter: 0,
+			});
+
+			await clock.advanceTimersByTimeAsync(70_000);
+			const results = await checkPromise;
+
+			assert.ok(!results.passed);
+			assert.strictEqual(retryEvents, expectedRetries);
+		});
+
 		it('should retry 5xx status code', async () => {
 			const mockPool = mockAgent.get('http://example.invalid');
 			mockPool.intercept({ path: '/', method: 'GET' }).reply(522, '');
@@ -279,7 +313,11 @@ describe('retries', () => {
 				.times(2);
 
 			const { promise, resolve } = invertedPromise();
-			const checker = new LinkChecker().on('retry', resolve);
+			let retryEvents = 0;
+			const checker = new LinkChecker().on('retry', () => {
+				retryEvents++;
+				resolve();
+			});
 			const clock = vi.useFakeTimers({ shouldAdvanceTime: true });
 			const checkPromise = checker.check({
 				path: 'test/fixtures/basic',
@@ -291,6 +329,7 @@ describe('retries', () => {
 			await clock.advanceTimersByTime(10000);
 			const results = await checkPromise;
 			assert.ok(!results.passed);
+			assert.strictEqual(retryEvents, 1);
 		});
 
 		it('should handle 429s without retry-after header as retry error', async () => {
@@ -314,9 +353,13 @@ describe('retries', () => {
 
 		it('should stop retrying 429s without retry-after header', async () => {
 			const mockPool = mockAgent.get('http://example.invalid');
-			mockPool.intercept({ path: '/', method: 'GET' }).reply(429, '');
+			mockPool.intercept({ path: '/', method: 'GET' }).reply(429, '').times(2);
 			const { promise, resolve } = invertedPromise();
-			const checker = new LinkChecker().on('retry', resolve);
+			let retryEvents = 0;
+			const checker = new LinkChecker().on('retry', () => {
+				retryEvents++;
+				resolve();
+			});
 			const clock = vi.useFakeTimers({ shouldAdvanceTime: true });
 			const checkPromise = checker.check({
 				path: 'test/fixtures/basic',
@@ -328,6 +371,7 @@ describe('retries', () => {
 			await clock.advanceTimersByTime(10000);
 			const results = await checkPromise;
 			assert.ok(!results.passed);
+			assert.strictEqual(retryEvents, 1);
 		});
 
 		it('should handle all retries failing without crashing (issue #754)', async () => {
@@ -362,8 +406,8 @@ describe('retries', () => {
 
 			// Should complete without crashing, with failed link result
 			assert.ok(!results.passed);
-			// Verify retries happened (exact count depends on HEAD/GET fallback)
-			assert.ok(retryCount.count >= 1);
+			// HEAD-to-GET fallback is part of an attempt, not an additional retry.
+			assert.strictEqual(retryCount.count, 1);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Make `retryErrorsCount` perform exactly the configured number of retries after the initial request.

Closes #859.

## Root cause

The retry cache was initialized to `1` on the first failure, but the stopping condition allowed retries while the cached value was less than or equal to the configured maximum. As a result, `retryErrorsCount: 1` scheduled retries numbered 1 and 2.

The cache now represents the number of retries already scheduled:

1. Read the current count, defaulting to zero.
2. Stop when the count is greater than or equal to the configured maximum.
3. Increment once when scheduling the next retry.

The exponential backoff sequence remains unchanged: retry 1 waits two seconds, retry 2 waits four seconds, and so on.

## Tests

- Added exact attempt and retry-event coverage for retry counts 0, 1, 2, and 5.
- Tightened connection-error and 429 coverage to assert exactly one retry when configured for one.
- Confirmed HEAD-to-GET fallback remains part of one attempt rather than consuming the retry budget.
- Full 246-test suite passed on Node 22, 24, and 26.
- Lint, TypeScript build, and `git diff --check` passed.

## Live verification

Against `https://httpbin.org/status/429` under Node 22 with:

```sh
--retry-errors --retry-errors-count 1 --retry-errors-jitter 0
```

Linkinator emitted exactly one retry and completed in approximately 2.5 seconds. Before this fix it emitted two retries and took approximately 4.6 seconds.
