### PR TITLE
fix: allow skipping client-side fragment validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ $ linkinator LOCATIONS [ --arguments ]
         Invalid fragments will be marked as broken. Only checks server-rendered HTML (not JavaScript-added fragments).
         Defaults to false.
 
+    --skip-fragment
+        List of regular expressions for fragments whose validation should be skipped.
+        The underlying URL is still checked. Can be specified multiple times.
+
     --redirects
         Control how redirects are handled. Options are 'allow' (default, follows redirects),
         'warn' (follows but emits warnings), or 'error' (treats redirects as broken).
@@ -266,6 +270,7 @@ All options are optional. It should look like this:
   "markdown": true,
   "checkCss": true,
   "checkFragments": true,
+  "skipFragment": ["^code/", "^show-examples$", "^/", "^!/"],
   "serverRoot": "./",
   "directoryListing": true,
   "cleanUrls": true,
@@ -402,6 +407,8 @@ Asynchronous method that runs a site wide scan. Options come in the form of an o
 - `port` (number) - When the `path` is provided as a local path on disk, the `port` on which to start the temporary web server.  Defaults to a random high range order port.
 - `recurse` (boolean) - By default, all scans are shallow.  Only the top level links on the requested page will be scanned.  By setting `recurse` to `true`, the crawler will follow all links on the page, and continue scanning links **on the same domain** for as long as it can go. Results are cached, so no worries about loops.
 - `checkCss` (boolean) - Extract and check URLs found in CSS properties (inline styles, `<style>` tags, and external CSS files when using `recurse`). This includes `url()` functions, `@import` statements, and other CSS URL references. Defaults to `false`.
+- `checkFragments` (boolean) - Validate fragment identifiers against server-rendered HTML. Defaults to `false`.
+- `fragmentsToSkip` (array | function) - Regular expression strings matched against decoded fragment identifiers, or an async function receiving the fragment and full URL. Matching fragments are reported as skipped while the underlying URL is still checked.
 - `retry` (boolean|RetryConfig) - Automatically retry requests that respond with an HTTP 429, and include a `retry-after` header.  The `RetryConfig` option is a placeholder for fine-grained controls to be implemented at a later time, and is only included here to signal forward-compatibility.
 - `serverRoot` (string) - When scanning a locally directory, customize the location on disk
 where the server is started.  Defaults to the path passed in `path`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,6 +71,10 @@ const cli = meow(
 			Invalid fragments will be marked as broken. Only checks server-rendered HTML (not JavaScript-added fragments).
 			Defaults to false.
 
+		--skip-fragment
+			List of regular expressions for fragments whose validation should be skipped.
+			The underlying URL is still checked. Can be specified multiple times.
+
 		--redirects
 			Control how redirects are handled. Options are 'allow' (default, follows redirects),
 			'warn' (follows but emits warnings), or 'error' (treats redirects as broken).
@@ -151,6 +155,7 @@ const cli = meow(
 			markdown: { type: 'boolean' },
 			checkCss: { type: 'boolean' },
 			checkFragments: { type: 'boolean' },
+			skipFragment: { type: 'string', isMultiple: true },
 			serverRoot: { type: 'string' },
 			verbosity: { type: 'string' },
 			directoryListing: { type: 'boolean' },
@@ -366,6 +371,20 @@ async function main() {
 			for (const skip of flags.skip) {
 				const rules = skip.split(/[\s,]+/).filter(Boolean);
 				options.linksToSkip.push(...rules);
+			}
+		}
+	}
+
+	if (flags.skipFragment) {
+		if (typeof flags.skipFragment === 'string') {
+			options.fragmentsToSkip = flags.skipFragment
+				.split(/[\s,]+/)
+				.filter(Boolean);
+		} else if (Array.isArray(flags.skipFragment)) {
+			options.fragmentsToSkip = [];
+			for (const skipFragment of flags.skipFragment) {
+				const rules = skipFragment.split(/[\s,]+/).filter(Boolean);
+				options.fragmentsToSkip.push(...rules);
 			}
 		}
 	}

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,7 @@ export type Flags = {
 	markdown?: boolean;
 	checkCss?: boolean;
 	checkFragments?: boolean;
+	skipFragment?: string | string[];
 	serverRoot?: string;
 	directoryListing?: boolean;
 	cleanUrls?: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -757,11 +757,30 @@ export class LinkChecker extends EventEmitter {
 					result.fragment &&
 					result.fragment.length > 0
 				) {
-					const urlKey = result.url.href;
-					if (!this.fragmentsToCheck.has(urlKey)) {
-						this.fragmentsToCheck.set(urlKey, new Set());
+					if (
+						await this.shouldSkipFragment(
+							result.fragment,
+							result.urlWithFragment ?? result.url.href,
+							options.checkOptions,
+						)
+					) {
+						const skippedFragmentResult: LinkResult = {
+							url: mapUrl(
+								result.urlWithFragment ?? result.url.href,
+								options.checkOptions,
+							),
+							state: LinkState.SKIPPED,
+							parent: mapUrl(options.url.href, options.checkOptions),
+						};
+						options.results.push(skippedFragmentResult);
+						this.emit('link', skippedFragmentResult);
+					} else {
+						const urlKey = result.url.href;
+						if (!this.fragmentsToCheck.has(urlKey)) {
+							this.fragmentsToCheck.set(urlKey, new Set());
+						}
+						this.fragmentsToCheck.get(urlKey)?.add(result.fragment);
 					}
-					this.fragmentsToCheck.get(urlKey)?.add(result.fragment);
 				}
 
 				let crawl =
@@ -931,6 +950,22 @@ export class LinkChecker extends EventEmitter {
 		return Boolean(
 			checkOptions.linksToSkip?.some((linkToSkip) =>
 				new RegExp(linkToSkip).test(href),
+			),
+		);
+	}
+
+	private async shouldSkipFragment(
+		fragment: string,
+		url: string,
+		checkOptions: InternalCheckOptions,
+	): Promise<boolean> {
+		if (typeof checkOptions.fragmentsToSkip === 'function') {
+			return checkOptions.fragmentsToSkip(fragment, url);
+		}
+
+		return Boolean(
+			checkOptions.fragmentsToSkip?.some((fragmentToSkip) =>
+				new RegExp(fragmentToSkip).test(fragment),
 			),
 		);
 	}

--- a/src/options.ts
+++ b/src/options.ts
@@ -33,6 +33,9 @@ export type CheckOptions = {
 	allowInsecureCerts?: boolean;
 	checkCss?: boolean;
 	checkFragments?: boolean;
+	fragmentsToSkip?:
+		| string[]
+		| ((fragment: string, url: string) => Promise<boolean>);
 	statusCodes?: Record<string, StatusCodeAction>;
 };
 

--- a/test/fixtures/config/linkinator.config.json
+++ b/test/fixtures/config/linkinator.config.json
@@ -4,5 +4,6 @@
   "silent": true,
   "concurrency": 17,
   "skip": "🌳",
+  "skipFragment": ["^code/", "^!/"],
   "directoryListing": false
 }

--- a/test/fixtures/fragments-client-state/index.html
+++ b/test/fixtures/fragments-client-state/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Client-side Fragment State Test</title>
+</head>
+<body>
+	<a href="./target.html#code/PTAE">Playground code</a>
+	<a href="./target.html#show-examples">Show examples</a>
+	<a href="./target.html#/route">Hash route</a>
+	<a href="./target.html#!/legacy-route">Legacy hash route</a>
+	<a href="./target.html#encoded%20state">Encoded state</a>
+	<a href="./target.html#missing-section">Missing static section</a>
+</body>
+</html>

--- a/test/fixtures/fragments-client-state/target.html
+++ b/test/fixtures/fragments-client-state/target.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Client-side Fragment Target</title>
+</head>
+<body>
+	<p>The application consumes fragment state after JavaScript loads.</p>
+</body>
+</html>

--- a/test/test.cli.ts
+++ b/test/test.cli.ts
@@ -331,6 +331,29 @@ describe('cli', () => {
 		assert.match(response.stderr, /Successfully scanned/);
 	});
 
+	it('should skip fragment validation without skipping the underlying URL', async () => {
+		const response = await execa(node, [
+			linkinator,
+			'test/fixtures/fragments-client-state',
+			'--check-fragments',
+			'--verbosity',
+			'INFO',
+			'--skip-fragment',
+			'^code/',
+			'--skip-fragment',
+			'^show-examples$,^/,^!/,^encoded\\sstate$,^missing-section$',
+		]);
+
+		assert.strictEqual(response.exitCode, 0);
+		const stdout = stripAnsi(response.stdout);
+		const skippedUrls = [...stdout.matchAll(/\[SKP] ([^\n]+)/g)].map((match) =>
+			match[1].trim(),
+		);
+		assert.strictEqual(new Set(skippedUrls).size, 6);
+		assert.match(stdout, /\[200].*[\\/]target\.html$/m);
+		assert.match(stripAnsi(response.stderr), /Successfully scanned/);
+	});
+
 	it('should warn on retries', async () => {
 		// Start a web server to return the 429
 		let requestCount = 0;

--- a/test/test.fragments.ts
+++ b/test/test.fragments.ts
@@ -169,6 +169,82 @@ describe('fragment identifier validation', () => {
 		expect(fragmentResult).toBeUndefined();
 	});
 
+	it('should skip matching fragment validation but still check the URL', async () => {
+		const mockPool = mockAgent.get('http://example.com');
+
+		mockPool
+			.intercept({ path: '/page.html', method: 'HEAD' })
+			.reply(200, '', { headers: { 'content-type': 'text/html' } });
+
+		const results = await check({
+			path: 'test/fixtures/fragments-invalid',
+			checkFragments: true,
+			fragmentsToSkip: ['^invalid-'],
+		});
+
+		expect(results.passed).toBe(true);
+		expect(
+			results.links.find((link) => link.url === 'http://example.com/page.html')
+				?.state,
+		).toBe(LinkState.OK);
+		expect(
+			results.links.find(
+				(link) => link.url === 'http://example.com/page.html#invalid-section',
+			)?.state,
+		).toBe(LinkState.SKIPPED);
+	});
+
+	it('should pass decoded fragments and full URLs to a skip function', async () => {
+		const received: Array<{ fragment: string; url: string }> = [];
+
+		const results = await check({
+			path: 'test/fixtures/fragments-client-state',
+			checkFragments: true,
+			fragmentsToSkip: async (fragment, url) => {
+				received.push({ fragment, url });
+				return true;
+			},
+		});
+
+		expect(results.passed).toBe(true);
+		const encodedState = received.find(
+			({ fragment }) => fragment === 'encoded state',
+		);
+		expect(encodedState?.url).toMatch(/\/target\.html#encoded%20state$/);
+		expect(
+			results.links.filter((link) => link.state === LinkState.SKIPPED),
+		).toHaveLength(6);
+	});
+
+	it('should skip common client-state fragments while retaining strict checks', async () => {
+		const results = await check({
+			path: 'test/fixtures/fragments-client-state',
+			checkFragments: true,
+			fragmentsToSkip: [
+				'^code/',
+				'^show-examples$',
+				'^/',
+				'^!/',
+				'^encoded state$',
+			],
+		});
+
+		expect(results.passed).toBe(false);
+		expect(
+			results.links.filter((link) => link.state === LinkState.SKIPPED),
+		).toHaveLength(5);
+		expect(
+			results.links.find((link) => link.url.endsWith('#missing-section'))
+				?.state,
+		).toBe(LinkState.BROKEN);
+		expect(
+			results.links.find(
+				(link) =>
+					/[\\/]target\.html$/.test(link.url) && link.state === LinkState.OK,
+			),
+		).toBeDefined();
+	});
+
 	it('should handle URL-encoded fragments', async () => {
 		const html = `
 			<html>


### PR DESCRIPTION
## Summary

- add `--skip-fragment` / `skipFragment` for CLI and config users
- add `fragmentsToSkip` regex/function support to the API
- report matching fragment checks as `SKIPPED` while still checking the fragmentless HTTP URL
- document the behavior and cover SPA state, hash routers, encoded fragments, strict non-matches, repeated CLI flags, and config loading

## Root cause

HTTP requests never send URL fragments to the server. Linkinator can verify traditional fragments against server-rendered HTML, but it cannot infer whether JavaScript will consume a fragment as application state. Treating every missing static identifier as definitely broken creates false positives for links such as TypeScript Playground `#code/...` URLs.

This change keeps strict fragment validation as the default and adds an explicit, fragment-specific escape hatch. Unlike `--skip`, it skips only fragment validation; the underlying URL is still requested and must pass.

## Validation

- `npm run build`
- `npm run lint` (passes; existing Biome schema-version informational notice remains)
- focused CLI/API/config/core tests: 138 passed
- full suite on current Node: 250 passed
- full suite on Node 22: 250 passed
- full suite on Node 26: 250 passed
- coverage suite: 250 passed; 94.01% statements / 88.9% branches / 97.95% functions / 93.95% lines
- `npm pack --dry-run`
- real tarball install plus installed CLI version/fragment checks
- all standalone binaries built; macOS binary version/fragment checks passed
- `npm run docs-test`: 17 live README links passed
- live issue reproduction on TypeScript docs:
  - strict mode: 15 fragment failures
  - skipping `^code/` and `^show-examples$`: only unrelated GitHub `#readme` remained strict/broken
  - adding explicit `^readme$`: 0 broken; client-state fragments skipped; TypeScript Playground and GitHub base URLs independently remained HTTP-OK

Closes #858
