### PR TITLE
fix: rewrite redirect targets and preserve recursive crawling

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,20 @@ where the server is started.  Defaults to the path passed in `path`.
     }
   ]
   ```
+  JavaScript configuration files may use `RegExp` patterns as shown above. In
+  `linkinator.config.json`, provide the pattern as a string instead:
+  ```json
+  {
+    "urlRewriteExpressions": [
+      {
+        "pattern": "^https://example\\.com",
+        "replacement": "http://localhost:3000"
+      }
+    ]
+  }
+  ```
+  Rewrites are applied to both discovered URLs and every target in an HTTP
+  redirect chain.
 
 - `userAgent` (string) - The [user agent](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent) that should be passed with each request. This uses a reasonable default.
 - `headers` (object) - Custom HTTP headers to include in all requests. Object with header names as keys and values as strings. These headers are merged with the default headers (including User-Agent). Example: `{ 'Authorization': 'Bearer token', 'X-Custom': 'value' }`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -389,6 +389,18 @@ async function main() {
 		}
 	}
 
+	if (flags.urlRewriteExpressions) {
+		options.urlRewriteExpressions = flags.urlRewriteExpressions.map(
+			(expression) => ({
+				pattern:
+					typeof expression.pattern === 'string'
+						? new RegExp(expression.pattern)
+						: expression.pattern,
+				replacement: expression.replacement,
+			}),
+		);
+	}
+
 	if (flags.urlRewriteSearch && flags.urlRewriteReplace) {
 		options.urlRewriteExpressions = [
 			{

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -177,6 +177,17 @@ const cli = meow(
 
 let flags: Flags;
 
+function compileRewritePattern(pattern: string | RegExp): RegExp {
+	if (pattern instanceof RegExp) {
+		return pattern;
+	}
+
+	// URL rewrite patterns are intentionally executable regex syntax supplied by
+	// the operator through a trusted local CLI or config file. Escaping them would
+	// break the documented configuration contract.
+	return new RegExp(pattern);
+}
+
 function isBunExecutable() {
 	// When compiled with `bun build --compile`, process.argv[0] is typically "bun".
 	// When run directly with `bun`, process.argv[0] is the path to the bun executable.
@@ -392,10 +403,7 @@ async function main() {
 	if (flags.urlRewriteExpressions) {
 		options.urlRewriteExpressions = flags.urlRewriteExpressions.map(
 			(expression) => ({
-				pattern:
-					typeof expression.pattern === 'string'
-						? new RegExp(expression.pattern)
-						: expression.pattern,
+				pattern: compileRewritePattern(expression.pattern),
 				replacement: expression.replacement,
 			}),
 		);
@@ -404,7 +412,7 @@ async function main() {
 	if (flags.urlRewriteSearch && flags.urlRewriteReplace) {
 		options.urlRewriteExpressions = [
 			{
-				pattern: new RegExp(flags.urlRewriteSearch),
+				pattern: compileRewritePattern(flags.urlRewriteSearch),
 				replacement: flags.urlRewriteReplace,
 			},
 		];

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,10 @@ export type Flags = {
 	retryErrorsJitter?: number;
 	urlRewriteSearch?: string;
 	urlRewriteReplace?: string;
+	urlRewriteExpressions?: Array<{
+		pattern: string | RegExp;
+		replacement: string;
+	}>;
 	header?: string[];
 	statusCode?: string | string[];
 	statusCodes?: Record<string, string>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,80 +3,7 @@ import type * as http from 'node:http';
 import type { AddressInfo } from 'node:net';
 import * as path from 'node:path';
 import process from 'node:process';
-import {
-	Agent,
-	EnvHttpProxyAgent,
-	type RequestInit,
-	fetch as undiciFetch,
-} from 'undici';
 import { getCssLinks, getLinks, validateFragments } from './links.js';
-
-// Shared HTTP agent for insecure certificate requests.
-// Using a single shared agent prevents port exhaustion from creating
-// new agents per request (which was the original bug).
-let sharedInsecureAgent: Agent | undefined;
-
-// Shared proxy agent, cached per proxy URL to avoid repeated allocations.
-let sharedProxyAgent: EnvHttpProxyAgent | undefined;
-let cachedProxyUrl: string | undefined;
-
-/**
- * Reset the shared HTTP agents. This is primarily useful for testing
- * to ensure a fresh agent state between tests.
- */
-export function resetSharedAgents(): void {
-	sharedInsecureAgent = undefined;
-	sharedProxyAgent = undefined;
-	cachedProxyUrl = undefined;
-}
-
-/**
- * Returns the proxy URL from well-known environment variables, or undefined
- * if none are set. Precedence: https_proxy > HTTPS_PROXY > http_proxy > HTTP_PROXY.
- */
-function getProxyUrl(): string | undefined {
-	const url =
-		process.env.https_proxy ??
-		process.env.HTTPS_PROXY ??
-		process.env.http_proxy ??
-		process.env.HTTP_PROXY;
-	return url || undefined;
-}
-
-function getSharedProxyAgent(proxyUrl: string): EnvHttpProxyAgent {
-	if (!sharedProxyAgent || cachedProxyUrl !== proxyUrl) {
-		sharedProxyAgent = new EnvHttpProxyAgent({
-			httpProxy: proxyUrl,
-			httpsProxy: proxyUrl,
-		});
-		cachedProxyUrl = proxyUrl;
-	}
-	return sharedProxyAgent;
-}
-
-/**
- * Get or create a shared HTTP agent that accepts insecure certificates.
- * This is used when allowInsecureCerts is enabled to bypass certificate
- * validation while still maintaining connection pooling.
- * @param _allowInsecureCerts Always true when called (parameter kept for clarity)
- * @returns The shared insecure agent instance
- */
-function getSharedAgent(_allowInsecureCerts: boolean): Agent {
-	if (!sharedInsecureAgent) {
-		sharedInsecureAgent = new Agent({
-			connect: {
-				rejectUnauthorized: false,
-			},
-			// Keep connections alive for reuse
-			keepAliveTimeout: 30_000,
-			keepAliveMaxTimeout: 60_000,
-			// Allow multiple connections per host for concurrency
-			connections: 100,
-		});
-	}
-	return sharedInsecureAgent;
-}
-
 import {
 	type CheckOptions,
 	type InternalCheckOptions,
@@ -84,12 +11,19 @@ import {
 	type StatusCodeAction,
 } from './options.js';
 import { Queue } from './queue.js';
+import {
+	type HttpResponse,
+	makeRequest,
+	type RedirectTarget,
+	type RequestResponse,
+} from './request.js';
 import { startWebServer, stopWebServer } from './server.js';
 import { bufferStream, drainStream, toNodeReadable } from './stream-utils.js';
 
 const STATIC_SERVER_HOST = '127.0.0.1';
 
 export { getConfig } from './config.js';
+export { type HttpResponse, resetSharedAgents } from './request.js';
 
 export enum LinkState {
 	OK = 'OK',
@@ -118,15 +52,6 @@ export type StatusCodeWarning = {
 	url: string;
 	status: number;
 };
-
-export type HttpResponse = {
-	status: number;
-	headers: Record<string, string>;
-	body?: ReadableStream;
-	url?: string;
-};
-
-type RequestResponse = HttpResponse & { redirectSkipped?: string };
 
 export type LinkResult = {
 	url: string;
@@ -307,15 +232,7 @@ export class LinkChecker extends EventEmitter {
 	 * @returns A list of crawl results consisting of urls and status codes
 	 */
 	async crawl(options: CrawlOptions): Promise<void> {
-		// Apply any regex url replacements
-		if (options.checkOptions.urlRewriteExpressions) {
-			for (const exp of options.checkOptions.urlRewriteExpressions) {
-				const newUrl = options.url.href.replace(exp.pattern, exp.replacement);
-				if (options.url.href !== newUrl) {
-					options.url.href = newUrl;
-				}
-			}
-		}
+		options.url.href = this.rewriteUrl(options.url.href, options.checkOptions);
 
 		if (await this.shouldSkipUrl(options.url.href, options.checkOptions)) {
 			this.recordSkippedResult(options);
@@ -350,15 +267,18 @@ export class LinkChecker extends EventEmitter {
 		const originalUrl = options.url.href;
 		const redirectMode =
 			options.checkOptions.redirects === 'error' ? 'manual' : 'follow';
+		const processRedirectTarget =
+			redirectMode === 'follow' &&
+			(this.hasSkipRules(options.checkOptions) ||
+				Boolean(options.checkOptions.urlRewriteExpressions?.length))
+				? (url: string) => this.processRedirectTarget(url, options.checkOptions)
+				: undefined;
 		const requestOptions = {
 			headers: options.checkOptions.headers,
 			timeout: options.checkOptions.timeout,
 			redirect: redirectMode,
 			allowInsecureCerts: options.checkOptions.allowInsecureCerts,
-			shouldSkipRedirect:
-				redirectMode === 'follow' && this.hasSkipRules(options.checkOptions)
-					? (url: string) => this.shouldSkipUrl(url, options.checkOptions)
-					: undefined,
+			processRedirectTarget,
 		} as const;
 
 		try {
@@ -934,6 +854,28 @@ export class LinkChecker extends EventEmitter {
 		);
 	}
 
+	private rewriteUrl(href: string, checkOptions: InternalCheckOptions): string {
+		let rewrittenUrl = href;
+		for (const expression of checkOptions.urlRewriteExpressions ?? []) {
+			rewrittenUrl = rewrittenUrl.replace(
+				expression.pattern,
+				expression.replacement,
+			);
+		}
+		return rewrittenUrl;
+	}
+
+	private async processRedirectTarget(
+		href: string,
+		checkOptions: InternalCheckOptions,
+	): Promise<RedirectTarget> {
+		const url = this.rewriteUrl(href, checkOptions);
+		return {
+			url,
+			shouldSkip: await this.shouldSkipUrl(url, checkOptions),
+		};
+	}
+
 	private async shouldSkipUrl(
 		href: string,
 		checkOptions: InternalCheckOptions,
@@ -1173,135 +1115,6 @@ function mapUrl<T extends string | undefined>(
 	}
 
 	return newUrl as T;
-}
-
-/**
- * Helper function to make HTTP requests using native fetch
- * @param method HTTP method
- * @param url URL to request
- * @param options Additional options (headers, timeout, allowInsecureCerts)
- * @returns Response with status, headers, and body stream
- */
-async function makeRequest(
-	method: string,
-	url: string,
-	options: {
-		headers?: Record<string, string>;
-		timeout?: number;
-		redirect?: 'follow' | 'manual';
-		allowInsecureCerts?: boolean;
-		shouldSkipRedirect?: (url: string) => Promise<boolean>;
-	} = {},
-): Promise<RequestResponse> {
-	// Build browser-like headers to avoid bot detection
-	const defaultHeaders: Record<string, string> = {
-		Accept:
-			'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
-		'Accept-Language': 'en-US,en;q=0.9',
-		'Accept-Encoding': 'gzip, deflate, br',
-		'Cache-Control': 'no-cache',
-		Pragma: 'no-cache',
-		'Sec-Fetch-Dest': 'document',
-		'Sec-Fetch-Mode': 'navigate',
-		'Sec-Fetch-Site': 'none',
-		'Upgrade-Insecure-Requests': '1',
-		'User-Agent': 'node',
-	};
-
-	let currentUrl = url;
-	let currentHeaders = { ...defaultHeaders, ...options.headers };
-	const manuallyFollow = Boolean(options.shouldSkipRedirect);
-	const signal = options.timeout
-		? AbortSignal.timeout(options.timeout)
-		: undefined;
-
-	for (let redirectCount = 0; ; redirectCount++) {
-		const requestOptions: RequestInit = {
-			method,
-			headers: currentHeaders,
-			redirect: manuallyFollow ? 'manual' : (options.redirect ?? 'follow'),
-		};
-
-		if (signal) {
-			requestOptions.signal = signal;
-		}
-
-		// For normal requests, use undici fetch so tests and callers can control
-		// request dispatching with undici.setGlobalDispatcher across Node versions.
-		// Custom agents are shared to preserve connection pooling.
-		const proxyUrl = getProxyUrl();
-		const response = options.allowInsecureCerts
-			? await undiciFetch(currentUrl, {
-					...requestOptions,
-					dispatcher: getSharedAgent(true),
-				})
-			: proxyUrl
-				? await undiciFetch(currentUrl, {
-						...requestOptions,
-						dispatcher: getSharedProxyAgent(proxyUrl),
-					})
-				: await undiciFetch(currentUrl, requestOptions);
-
-		const headers: Record<string, string> = {};
-		response.headers.forEach((value: string, key: string) => {
-			headers[key] = value;
-		});
-
-		const result: HttpResponse = {
-			status: response.status,
-			headers,
-			body: (response.body ?? undefined) as ReadableStream | undefined,
-			url: response.url,
-		};
-
-		const location = headers.location;
-		if (
-			!manuallyFollow ||
-			!isFetchRedirectStatus(response.status) ||
-			!location
-		) {
-			return result;
-		}
-
-		const targetUrl = new URL(location, currentUrl).href;
-		if (await options.shouldSkipRedirect?.(targetUrl)) {
-			await drainStream(result.body);
-			return { ...result, body: undefined, redirectSkipped: targetUrl };
-		}
-
-		if (redirectCount >= 20) {
-			await drainStream(result.body);
-			throw new TypeError('redirect count exceeded');
-		}
-
-		const currentOrigin = new URL(currentUrl).origin;
-		const targetOrigin = new URL(targetUrl).origin;
-		if (currentOrigin !== targetOrigin) {
-			currentHeaders = stripSensitiveHeaders(currentHeaders);
-		}
-
-		await drainStream(result.body);
-		currentUrl = targetUrl;
-	}
-}
-
-function isFetchRedirectStatus(status: number): boolean {
-	return [301, 302, 303, 307, 308].includes(status);
-}
-
-function stripSensitiveHeaders(
-	headers: Record<string, string>,
-): Record<string, string> {
-	const sensitiveHeaders = new Set([
-		'authorization',
-		'cookie',
-		'proxy-authorization',
-	]);
-	return Object.fromEntries(
-		Object.entries(headers).filter(
-			([name]) => !sensitiveHeaders.has(name.toLowerCase()),
-		),
-	);
 }
 
 /**

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,0 +1,189 @@
+import process from 'node:process';
+import {
+	Agent,
+	EnvHttpProxyAgent,
+	type RequestInit,
+	fetch as undiciFetch,
+} from 'undici';
+import { drainStream } from './stream-utils.js';
+
+export type HttpResponse = {
+	status: number;
+	headers: Record<string, string>;
+	body?: ReadableStream;
+	url?: string;
+};
+
+export type RequestResponse = HttpResponse & { redirectSkipped?: string };
+
+export type RedirectTarget = {
+	url: string;
+	shouldSkip: boolean;
+};
+
+type ProcessRedirectTarget = (url: string) => Promise<RedirectTarget>;
+
+type RequestOptions = {
+	headers?: Record<string, string>;
+	timeout?: number;
+	redirect: 'follow' | 'manual';
+	allowInsecureCerts?: boolean;
+	processRedirectTarget?: ProcessRedirectTarget;
+};
+
+const DEFAULT_HEADERS: Record<string, string> = {
+	Accept:
+		'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+	'Accept-Language': 'en-US,en;q=0.9',
+	'Accept-Encoding': 'gzip, deflate, br',
+	'Cache-Control': 'no-cache',
+	Pragma: 'no-cache',
+	'Sec-Fetch-Dest': 'document',
+	'Sec-Fetch-Mode': 'navigate',
+	'Sec-Fetch-Site': 'none',
+	'Upgrade-Insecure-Requests': '1',
+	'User-Agent': 'node',
+};
+
+const SENSITIVE_HEADERS = new Set([
+	'authorization',
+	'cookie',
+	'proxy-authorization',
+]);
+
+let sharedInsecureAgent: Agent | undefined;
+let sharedProxyAgent: EnvHttpProxyAgent | undefined;
+let cachedProxyUrl: string | undefined;
+
+/** Reset shared HTTP agents, primarily to isolate tests. */
+export function resetSharedAgents(): void {
+	sharedInsecureAgent = undefined;
+	sharedProxyAgent = undefined;
+	cachedProxyUrl = undefined;
+}
+
+/** Make an HTTP request, applying redirect policy when one is provided. */
+export async function makeRequest(
+	method: string,
+	url: string,
+	options: RequestOptions,
+): Promise<RequestResponse> {
+	let currentUrl = url;
+	let currentHeaders = { ...DEFAULT_HEADERS, ...options.headers };
+	const processRedirectTarget = options.processRedirectTarget;
+	const signal = options.timeout
+		? AbortSignal.timeout(options.timeout)
+		: undefined;
+
+	for (let redirectCount = 0; ; redirectCount++) {
+		const requestOptions: RequestInit = {
+			method,
+			headers: currentHeaders,
+			redirect: processRedirectTarget ? 'manual' : options.redirect,
+			signal,
+		};
+		const response = await fetchUrl(
+			currentUrl,
+			requestOptions,
+			options.allowInsecureCerts,
+		);
+		const headers = Object.fromEntries(response.headers.entries());
+		const result: HttpResponse = {
+			status: response.status,
+			headers,
+			body: (response.body ?? undefined) as ReadableStream | undefined,
+			url: processRedirectTarget ? currentUrl : response.url,
+		};
+
+		const location = headers.location;
+		if (
+			!processRedirectTarget ||
+			!isFetchRedirectStatus(response.status) ||
+			!location
+		) {
+			return result;
+		}
+
+		const resolvedTargetUrl = new URL(location, currentUrl).href;
+		const target = await processRedirectTarget(resolvedTargetUrl);
+		if (target.shouldSkip) {
+			await drainStream(result.body);
+			return { ...result, body: undefined, redirectSkipped: target.url };
+		}
+		if (redirectCount >= 20) {
+			await drainStream(result.body);
+			throw new TypeError('redirect count exceeded');
+		}
+
+		if (new URL(currentUrl).origin !== new URL(target.url).origin) {
+			currentHeaders = stripSensitiveHeaders(currentHeaders);
+		}
+		await drainStream(result.body);
+		currentUrl = target.url;
+	}
+}
+
+async function fetchUrl(
+	url: string,
+	requestOptions: RequestInit,
+	allowInsecureCerts?: boolean,
+) {
+	if (allowInsecureCerts) {
+		return undiciFetch(url, {
+			...requestOptions,
+			dispatcher: getSharedInsecureAgent(),
+		});
+	}
+
+	const proxyUrl = getProxyUrl();
+	return proxyUrl
+		? undiciFetch(url, {
+				...requestOptions,
+				dispatcher: getSharedProxyAgent(proxyUrl),
+			})
+		: undiciFetch(url, requestOptions);
+}
+
+function getProxyUrl(): string | undefined {
+	const url =
+		process.env.https_proxy ??
+		process.env.HTTPS_PROXY ??
+		process.env.http_proxy ??
+		process.env.HTTP_PROXY;
+	return url || undefined;
+}
+
+function getSharedProxyAgent(proxyUrl: string): EnvHttpProxyAgent {
+	if (!sharedProxyAgent || cachedProxyUrl !== proxyUrl) {
+		sharedProxyAgent = new EnvHttpProxyAgent({
+			httpProxy: proxyUrl,
+			httpsProxy: proxyUrl,
+		});
+		cachedProxyUrl = proxyUrl;
+	}
+	return sharedProxyAgent;
+}
+
+function getSharedInsecureAgent(): Agent {
+	sharedInsecureAgent ??= new Agent({
+		connect: { rejectUnauthorized: false },
+		keepAliveTimeout: 30_000,
+		keepAliveMaxTimeout: 60_000,
+		connections: 100,
+	});
+	return sharedInsecureAgent;
+}
+
+function isFetchRedirectStatus(status: number): boolean {
+	return [301, 302, 303, 307, 308].includes(status);
+}
+
+function stripSensitiveHeaders(
+	headers: Record<string, string>,
+): Record<string, string> {
+	return Object.fromEntries(
+		Object.entries(headers).filter(
+			([name]) => !SENSITIVE_HEADERS.has(name.toLowerCase()),
+		),
+	);
+}

--- a/test/fixtures/config/url-rewrite-expressions.json
+++ b/test/fixtures/config/url-rewrite-expressions.json
@@ -1,0 +1,8 @@
+{
+  "urlRewriteExpressions": [
+    {
+      "pattern": "/legacy-target$",
+      "replacement": "/rewritten-target"
+    }
+  ]
+}

--- a/test/fixtures/config/url-rewrite-expressions.mjs
+++ b/test/fixtures/config/url-rewrite-expressions.mjs
@@ -1,0 +1,8 @@
+export default {
+	urlRewriteExpressions: [
+		{
+			pattern: /\/legacy-target$/,
+			replacement: '/rewritten-target',
+		},
+	],
+};

--- a/test/test.cli.ts
+++ b/test/test.cli.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import http from 'node:http';
+import type { AddressInfo } from 'node:net';
 import util from 'node:util';
 import { execa } from 'execa';
 import stripAnsi from 'strip-ansi';
@@ -329,6 +330,59 @@ describe('cli', () => {
 			'test/fixtures/rewrite/README.md',
 		]);
 		assert.match(response.stderr, /Successfully scanned/);
+	});
+
+	it('should respect URL rewrite expressions from config files across redirects', async () => {
+		const requestedPaths: string[] = [];
+		server = http.createServer((request, response) => {
+			requestedPaths.push(request.url || '');
+			if (request.url === '/start') {
+				response.writeHead(302, { Location: '/legacy-target' });
+				response.end();
+				return;
+			}
+			if (request.url === '/rewritten-target') {
+				response.writeHead(403, { 'cf-mitigated': 'challenge' });
+				response.end('challenge');
+				return;
+			}
+			response.writeHead(500);
+			response.end('unrewritten target requested');
+		});
+		await new Promise<void>((resolve) => server.listen(0, resolve));
+		const address = server.address() as AddressInfo;
+		const startUrl = `http://localhost:${address.port}/start`;
+
+		for (const config of [
+			'test/fixtures/config/url-rewrite-expressions.json',
+			'test/fixtures/config/url-rewrite-expressions.mjs',
+		]) {
+			const response = await execa(node, [
+				linkinator,
+				startUrl,
+				'--config',
+				config,
+				'--format',
+				'json',
+				'--verbosity',
+				'info',
+			]);
+			const result = JSON.parse(response.stdout) as {
+				passed: boolean;
+				links: LinkResult[];
+			};
+			assert.ok(result.passed);
+			assert.strictEqual(result.links[0].url, startUrl);
+			assert.strictEqual(result.links[0].status, 403);
+			assert.strictEqual(result.links[0].state, LinkState.SKIPPED);
+		}
+
+		assert.deepStrictEqual(requestedPaths, [
+			'/start',
+			'/rewritten-target',
+			'/start',
+			'/rewritten-target',
+		]);
 	});
 
 	it('should skip fragment validation without skipping the underlying URL', async () => {

--- a/test/test.redirect-rewrites.ts
+++ b/test/test.redirect-rewrites.ts
@@ -1,0 +1,239 @@
+import http, { type RequestListener } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, assert, describe, it } from 'vitest';
+import {
+	check,
+	LinkChecker,
+	LinkState,
+	type RedirectInfo,
+} from '../src/index.js';
+
+describe('redirect URL rewrites', () => {
+	const servers: http.Server[] = [];
+
+	async function serve(handler: RequestListener): Promise<string> {
+		const server = http.createServer(handler);
+		servers.push(server);
+		await new Promise<void>((resolve, reject) => {
+			server.listen(0, resolve);
+			server.on('error', reject);
+		});
+		const address = server.address() as AddressInfo;
+		return `http://localhost:${address.port}`;
+	}
+
+	afterEach(async () => {
+		await Promise.all(
+			servers.splice(0).map(
+				(server) =>
+					new Promise<void>((resolve, reject) => {
+						server.close((error) => (error ? reject(error) : resolve()));
+					}),
+			),
+		);
+	});
+
+	it('rewrites a redirect target before requesting it', async () => {
+		let legacyTargetRequests = 0;
+		const legacyUrl = await serve((_request, response) => {
+			legacyTargetRequests++;
+			response.writeHead(500);
+			response.end('legacy target should not be requested');
+		});
+
+		let rewrittenTargetRequests = 0;
+		const rewrittenUrl = await serve((_request, response) => {
+			rewrittenTargetRequests++;
+			response.writeHead(403, { 'cf-mitigated': 'challenge' });
+			response.end('challenge');
+		});
+
+		const redirectUrl = await serve((_request, response) => {
+			response.writeHead(302, { Location: `${legacyUrl}/citation/paper` });
+			response.end();
+		});
+
+		const startUrl = `${redirectUrl}/doi/paper`;
+		const results = await check({
+			path: startUrl,
+			urlRewriteExpressions: [
+				{
+					pattern: new RegExp(`^${legacyUrl}/citation/`),
+					replacement: `${rewrittenUrl}/doi/`,
+				},
+			],
+		});
+
+		assert.ok(results.passed);
+		assert.strictEqual(results.links[0].url, startUrl);
+		assert.strictEqual(results.links[0].status, 403);
+		assert.strictEqual(results.links[0].state, LinkState.SKIPPED);
+		assert.strictEqual(legacyTargetRequests, 0);
+		assert.strictEqual(rewrittenTargetRequests, 1);
+	});
+
+	it('applies rewrites to every target in a redirect chain', async () => {
+		const requestedPaths: string[] = [];
+		const serverUrl = await serve((request, response) => {
+			requestedPaths.push(request.url || '');
+			if (request.url === '/start') {
+				response.writeHead(302, { Location: '/legacy-middle' });
+				response.end();
+				return;
+			}
+			if (request.url === '/middle') {
+				response.writeHead(307, { Location: '/legacy-final' });
+				response.end();
+				return;
+			}
+			response.writeHead(request.url === '/final' ? 200 : 500);
+			response.end(request.url === '/final' ? 'ok' : 'unrewritten target');
+		});
+
+		const results = await check({
+			path: `${serverUrl}/start`,
+			urlRewriteExpressions: [{ pattern: /\/legacy-/, replacement: '/' }],
+		});
+
+		assert.ok(results.passed);
+		assert.strictEqual(results.links[0].status, 200);
+		assert.deepStrictEqual(requestedPaths, ['/start', '/middle', '/final']);
+	});
+
+	it('applies multiple rewrite expressions in sequence', async () => {
+		const requestedPaths: string[] = [];
+		const serverUrl = await serve((request, response) => {
+			requestedPaths.push(request.url || '');
+			if (request.url === '/start') {
+				response.writeHead(302, { Location: '/legacy-target' });
+				response.end();
+				return;
+			}
+			response.writeHead(request.url === '/final-target' ? 200 : 500);
+			response.end();
+		});
+
+		const results = await check({
+			path: `${serverUrl}/start`,
+			urlRewriteExpressions: [
+				{ pattern: /\/legacy-target$/, replacement: '/intermediate' },
+				{ pattern: /\/intermediate$/, replacement: '/final-target' },
+			],
+		});
+
+		assert.ok(results.passed);
+		assert.deepStrictEqual(requestedPaths, ['/start', '/final-target']);
+	});
+
+	it('checks skip rules after rewriting the redirect target', async () => {
+		const requestedPaths: string[] = [];
+		const serverUrl = await serve((request, response) => {
+			requestedPaths.push(request.url || '');
+			response.writeHead(302, { Location: '/legacy-target' });
+			response.end();
+		});
+
+		const results = await check({
+			path: `${serverUrl}/start`,
+			urlRewriteExpressions: [
+				{ pattern: /\/legacy-target$/, replacement: '/rewritten-target' },
+			],
+			linksToSkip: [`${serverUrl}/rewritten-target`],
+		});
+
+		assert.ok(results.passed);
+		assert.strictEqual(results.links[0].state, LinkState.SKIPPED);
+		assert.deepStrictEqual(requestedPaths, ['/start']);
+	});
+
+	it('skips a redirect target rewritten to a non-HTTP URL', async () => {
+		const requestedPaths: string[] = [];
+		const serverUrl = await serve((request, response) => {
+			requestedPaths.push(request.url || '');
+			response.writeHead(302, { Location: '/legacy-target' });
+			response.end();
+		});
+
+		const results = await check({
+			path: `${serverUrl}/start`,
+			urlRewriteExpressions: [
+				{
+					pattern: /^https?:\/\/.*\/legacy-target$/,
+					replacement: 'mailto:test@example.com',
+				},
+			],
+		});
+
+		assert.ok(results.passed);
+		assert.strictEqual(results.links[0].state, LinkState.SKIPPED);
+		assert.deepStrictEqual(requestedPaths, ['/start']);
+	});
+
+	it('strips sensitive headers when a rewrite changes the target origin', async () => {
+		let receivedHeaders: http.IncomingHttpHeaders = {};
+		const targetUrl = await serve((request, response) => {
+			receivedHeaders = request.headers;
+			response.writeHead(200);
+			response.end('ok');
+		});
+		const redirectUrl = await serve((_request, response) => {
+			response.writeHead(302, { Location: '/legacy-target' });
+			response.end();
+		});
+
+		const results = await check({
+			path: `${redirectUrl}/start`,
+			urlRewriteExpressions: [
+				{
+					pattern: new RegExp(`^${redirectUrl}/legacy-target$`),
+					replacement: `${targetUrl}/target`,
+				},
+			],
+			headers: {
+				Authorization: 'Bearer secret',
+				Cookie: 'session=secret',
+				'Proxy-Authorization': 'Basic secret',
+				'X-Linkinator-Test': 'preserved',
+			},
+		});
+
+		assert.ok(results.passed);
+		assert.strictEqual(receivedHeaders.authorization, undefined);
+		assert.strictEqual(receivedHeaders.cookie, undefined);
+		assert.strictEqual(receivedHeaders['proxy-authorization'], undefined);
+		assert.strictEqual(receivedHeaders['x-linkinator-test'], 'preserved');
+	});
+
+	it('reports the rewritten final URL in redirect warnings', async () => {
+		const serverUrl = await serve((request, response) => {
+			if (request.url === '/start') {
+				response.writeHead(302, { Location: '/legacy-target' });
+				response.end();
+				return;
+			}
+			response.writeHead(200);
+			response.end('ok');
+		});
+		const checker = new LinkChecker();
+		const warnings: RedirectInfo[] = [];
+		checker.on('redirect', (info) => warnings.push(info));
+
+		const results = await checker.check({
+			path: `${serverUrl}/start`,
+			redirects: 'warn',
+			urlRewriteExpressions: [
+				{ pattern: /\/legacy-target$/, replacement: '/rewritten-target' },
+			],
+		});
+
+		assert.ok(results.passed);
+		assert.deepStrictEqual(warnings, [
+			{
+				url: `${serverUrl}/start`,
+				targetUrl: `${serverUrl}/rewritten-target`,
+				status: 200,
+				isNonStandard: false,
+			},
+		]);
+	});
+});

--- a/test/test.redirects.ts
+++ b/test/test.redirects.ts
@@ -397,6 +397,65 @@ describe('redirects', () => {
 	});
 
 	describe('skip rules', () => {
+		it('recursively checks links from the final redirect target', async () => {
+			const requestedPaths: string[] = [];
+			const crawlServer = http.createServer((req, res) => {
+				requestedPaths.push(req.url || '');
+				if (req.url === '/') {
+					res.writeHead(200, { 'Content-Type': 'text/html' });
+					res.end('<a href="/redirect">redirect</a>');
+					return;
+				}
+				if (req.url === '/redirect') {
+					res.writeHead(302, { Location: '/nested/' });
+					res.end();
+					return;
+				}
+				if (req.url === '/nested/') {
+					res.writeHead(200, { 'Content-Type': 'text/html' });
+					res.end('<a href="child">child</a>');
+					return;
+				}
+				if (req.url === '/nested/child') {
+					res.writeHead(200, { 'Content-Type': 'text/html' });
+					res.end('<a href="grandchild">grandchild</a>');
+					return;
+				}
+				res.writeHead(404);
+				res.end('missing');
+			});
+			await new Promise<void>((resolve) => crawlServer.listen(0, resolve));
+			const address = crawlServer.address() as AddressInfo;
+			const serverUrl = `http://localhost:${address.port}`;
+
+			try {
+				const results = await check({
+					path: `${serverUrl}/`,
+					recurse: true,
+					linksToSkip: ['^(?!http://localhost)'],
+					retryErrors: true,
+				});
+
+				assert.ok(!results.passed);
+				assert.ok(
+					results.links.some(
+						(link) =>
+							link.url === `${serverUrl}/nested/grandchild` &&
+							link.state === LinkState.BROKEN,
+					),
+				);
+				assert.deepStrictEqual(requestedPaths, [
+					'/',
+					'/redirect',
+					'/nested/',
+					'/nested/child',
+					'/nested/grandchild',
+				]);
+			} finally {
+				crawlServer.close();
+			}
+		});
+
 		it('does not request a skipped redirect target', async () => {
 			let targetRequests = 0;
 			const targetServer = http.createServer((_req, res) => {
@@ -562,7 +621,7 @@ describe('redirects', () => {
 			}
 		});
 
-		it('keeps redirects in error mode broken without applying target skips', async () => {
+		it('keeps redirects in error mode broken without processing the target', async () => {
 			let targetRequests = 0;
 			const errorModeServer = http.createServer((req, res) => {
 				if (req.url === '/redirect') {
@@ -581,6 +640,9 @@ describe('redirects', () => {
 				const results = await check({
 					path: `${serverUrl}/redirect`,
 					linksToSkip: [`${serverUrl}/target`],
+					urlRewriteExpressions: [
+						{ pattern: /\/target$/, replacement: '/rewritten-target' },
+					],
 					redirects: 'error',
 				});
 				assert.ok(!results.passed);


### PR DESCRIPTION
## Summary

- apply URL rewrite expressions to every HTTP redirect target before requesting or evaluating skip rules
- support `urlRewriteExpressions` from JSON and JavaScript config files in the CLI
- preserve the effective final URL when redirects are followed manually so recursive relative links are resolved and crawled from the destination page
- isolate HTTP transport and redirect mechanics in a focused request module with one typed rewrite-and-skip policy
- document redirect rewrite behavior and JSON pattern syntax

## Root cause

URL rewrites were only applied when a URL first entered `crawl()`. Redirect targets were followed inside `makeRequest()` without passing through the rewrite pipeline, so rewritten destinations could still hit the original host.

Manual redirect handling also relied on the fetch response's URL metadata for the effective destination. Tracking the final URL explicitly makes recursive parsing deterministic and ensures relative links discovered on the redirect destination use the correct base URL.

## User impact

Redirected URLs now behave consistently with directly discovered URLs: rewrites run at every hop, skip rules see the rewritten destination, sensitive headers remain protected across origin changes, and destination documents continue to contribute recursively discovered links.

The maintainability review also reduced `src/index.ts` by 187 lines relative to `main` and kept redirect rewrite coverage out of the existing redirect test file, which would otherwise have crossed 1,000 lines.

Fixes #877.
Fixes #875.

## Validation

- `npm run build`
- `npm test -- --run` — 259 tests passed
- `npm run coverage` — 94.03% statements, 89.06% branches, 98% functions
- `npm run lint`
- `npm run docs-test` — 17 links passed
- `npm pack --dry-run --json`
- `npm run build-binaries`
- Node CLI and macOS standalone binary `--version` smoke tests
