### PR TITLE
fix: preserve local crawl origin through redirects

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -110,7 +110,13 @@ async function handleRequest(
 			response.statusCode = 301;
 			response.setHeader('Content-Type', 'text/html; charset=UTF-8');
 			response.setHeader('Content-Length', Buffer.byteLength(document));
-			response.setHeader('Location', redirectUrl.href);
+			// Keep the redirect relative so the client preserves the hostname it used
+			// to reach the temporary server. An absolute localhost URL changes the
+			// origin of crawls started on 127.0.0.1 and stops recursive traversal.
+			response.setHeader(
+				'Location',
+				`${redirectUrl.pathname}${redirectUrl.search}${redirectUrl.hash}`,
+			);
 			response.end(document);
 			return;
 		}

--- a/test/fixtures/redirect-recurse/child-one/grandchild/index.html
+++ b/test/fixtures/redirect-recurse/child-one/grandchild/index.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<a href="/broken">Broken</a>
+</body>
+</html>

--- a/test/fixtures/redirect-recurse/child-one/index.html
+++ b/test/fixtures/redirect-recurse/child-one/index.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<a href="grandchild">Grandchild</a>
+</body>
+</html>

--- a/test/fixtures/redirect-recurse/child-two/grandchild/index.html
+++ b/test/fixtures/redirect-recurse/child-two/grandchild/index.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<a href="/also-broken">Also broken</a>
+</body>
+</html>

--- a/test/fixtures/redirect-recurse/child-two/index.html
+++ b/test/fixtures/redirect-recurse/child-two/index.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<a href="grandchild">Grandchild</a>
+</body>
+</html>

--- a/test/fixtures/redirect-recurse/index.html
+++ b/test/fixtures/redirect-recurse/index.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+<a href="/child-one/">Child one</a>
+<a href="/child-two">Child two</a>
+</body>
+</html>

--- a/test/test.index.ts
+++ b/test/test.index.ts
@@ -377,6 +377,16 @@ describe('linkinator', () => {
 
 		assert.deepStrictEqual(brokenLinks, ['also-broken', 'broken']);
 		assert.strictEqual(results.links.length, 7);
+		assert.ok(
+			results.links.every((link) => !link.url.startsWith('http://localhost:')),
+		);
+		assert.ok(
+			results.links.some(
+				(link) =>
+					path.basename(link.url) === 'also-broken' &&
+					link.parent?.endsWith(path.join('child-two', 'grandchild')),
+			),
+		);
 	});
 
 	it('should not recurse non-html files', async () => {

--- a/test/test.index.ts
+++ b/test/test.index.ts
@@ -365,6 +365,20 @@ describe('linkinator', () => {
 		assert.strictEqual(results.links.length, 4);
 	});
 
+	it('should recurse through local directory redirects without changing hosts', async () => {
+		const results = await check({
+			path: 'test/fixtures/redirect-recurse',
+			recurse: true,
+		});
+		const brokenLinks = results.links
+			.filter((link) => link.state === LinkState.BROKEN)
+			.map((link) => path.basename(link.url))
+			.sort();
+
+		assert.deepStrictEqual(brokenLinks, ['also-broken', 'broken']);
+		assert.strictEqual(results.links.length, 7);
+	});
+
 	it('should not recurse non-html files', async () => {
 		const results = await check({
 			path: 'test/fixtures/scripts',

--- a/test/test.server.ts
+++ b/test/test.server.ts
@@ -117,6 +117,14 @@ describe('server', () => {
 			redirectResponse.headers.get('location'),
 			'/checkout/?services=setup-cctv',
 		);
+		assert.strictEqual(
+			redirectResponse.headers.get('content-type'),
+			'text/html; charset=UTF-8',
+		);
+		assert.strictEqual(
+			await redirectResponse.text(),
+			"<html><body>Redirectin'</body></html>",
+		);
 
 		const response = await undiciFetch(url);
 		const data = await response.text();
@@ -126,6 +134,41 @@ describe('server', () => {
 			`${rootUrl}/checkout/?services=setup-cctv`,
 		);
 		assert.strictEqual(data, '<html><body>Checkout page</body></html>');
+	});
+
+	it('should return a relative redirect for a directory without a query', async () => {
+		const response = await undiciFetch(`${rootUrl}/checkout`, {
+			redirect: 'manual',
+		});
+
+		assert.strictEqual(response.status, 301);
+		assert.strictEqual(response.headers.get('location'), '/checkout/');
+	});
+
+	it('should preserve encoded query values in directory redirects', async () => {
+		const response = await undiciFetch(
+			`${rootUrl}/5.0?return=%2Fdocs%2Fapi&tag=one&tag=two`,
+			{ redirect: 'manual' },
+		);
+
+		assert.strictEqual(response.status, 301);
+		assert.strictEqual(
+			response.headers.get('location'),
+			'/5.0/?return=%2Fdocs%2Fapi&tag=one&tag=two',
+		);
+	});
+
+	it('should not redirect a directory path that already has a slash', async () => {
+		const response = await undiciFetch(`${rootUrl}/checkout/`, {
+			redirect: 'manual',
+		});
+
+		assert.strictEqual(response.status, 200);
+		assert.strictEqual(response.headers.get('location'), null);
+		assert.strictEqual(
+			await response.text(),
+			'<html><body>Checkout page</body></html>',
+		);
 	});
 });
 

--- a/test/test.server.ts
+++ b/test/test.server.ts
@@ -111,9 +111,20 @@ describe('server', () => {
 		// This reproduces issue #595 - /checkout?services=setup-cctv
 		// where /checkout is a directory that should redirect to /checkout/
 		const url = `${rootUrl}/checkout?services=setup-cctv`;
+		const redirectResponse = await undiciFetch(url, { redirect: 'manual' });
+		assert.strictEqual(redirectResponse.status, 301);
+		assert.strictEqual(
+			redirectResponse.headers.get('location'),
+			'/checkout/?services=setup-cctv',
+		);
+
 		const response = await undiciFetch(url);
 		const data = await response.text();
 		assert.strictEqual(response.status, 200);
+		assert.strictEqual(
+			response.url,
+			`${rootUrl}/checkout/?services=setup-cctv`,
+		);
 		assert.strictEqual(data, '<html><body>Checkout page</body></html>');
 	});
 });


### PR DESCRIPTION
## Summary

- emit relative directory redirects from Linkinator's temporary static server
- preserve the hostname and query string used to start a local crawl
- add an end-to-end regression fixture matching the nested redirect case from #883

## Root cause

Local crawls start on `127.0.0.1`, but directory redirects were emitted as absolute `localhost` URLs. The hostname change made redirected descendants look external, so they were checked but not recursively parsed.

## Verification

- `npm ci`
- `npm test` — 263 tests passed
- `npm run lint`
- `npm run coverage` — statements 94.01%, branches 88.96%, functions 98.00%, lines 93.95%
- verified the reporter's reproduction against source, an installed npm tarball, and the compiled macOS binary; all find both broken links
- added focused coverage for redirect response compatibility, query encoding, already-slashed directories, crawl hostname preservation, and broken-link parentage

Fixes #883
