### PR TITLE
fix: report redirect destinations in error mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1192,8 +1192,25 @@ function detectRedirect(
 } {
 	const isRedirectStatus = status >= 300 && status < 400;
 	const urlChanged = response?.url && response.url !== originalUrl;
-	const hasLocation = Boolean(response?.headers.location);
+	const location = response?.headers.location;
+	const hasLocation = Boolean(location);
 	const hasBody = response?.body !== undefined;
+	let targetUrl: string | undefined;
+
+	if (isRedirectStatus && location) {
+		// Manual mode leaves response.url at the requested URL. The Location header
+		// identifies this redirect's immediate destination without following it.
+		try {
+			targetUrl = new URL(location, response?.url || originalUrl).href;
+		} catch {
+			// Preserve malformed Location values for diagnostics instead of hiding them.
+			targetUrl = location;
+		}
+	} else if (urlChanged) {
+		// A followed redirect has no Location header on its final response, so the
+		// response URL is the best available destination.
+		targetUrl = response.url;
+	}
 
 	// Non-standard redirect: 3xx status without Location header or with body
 	const isNonStandard =
@@ -1203,7 +1220,7 @@ function detectRedirect(
 		isRedirect: isRedirectStatus,
 		wasFollowed: Boolean(urlChanged || (isRedirectStatus && hasBody)),
 		isNonStandard,
-		targetUrl: response?.url || response?.headers.location,
+		targetUrl,
 	};
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1193,11 +1193,11 @@ function detectRedirect(
 	const isRedirectStatus = status >= 300 && status < 400;
 	const urlChanged = response?.url && response.url !== originalUrl;
 	const location = response?.headers.location;
-	const hasLocation = Boolean(location);
+	const hasLocation = location !== undefined;
 	const hasBody = response?.body !== undefined;
 	let targetUrl: string | undefined;
 
-	if (isRedirectStatus && location) {
+	if (isRedirectStatus && hasLocation) {
 		// Manual mode leaves response.url at the requested URL. The Location header
 		// identifies this redirect's immediate destination without following it.
 		try {
@@ -1212,9 +1212,8 @@ function detectRedirect(
 		targetUrl = response.url;
 	}
 
-	// Non-standard redirect: 3xx status without Location header or with body
-	const isNonStandard =
-		isRedirectStatus && (!hasLocation || (hasBody && !hasLocation));
+	// Non-standard redirect: 3xx status without a Location header.
+	const isNonStandard = isRedirectStatus && !hasLocation;
 
 	return {
 		isRedirect: isRedirectStatus,

--- a/test/test.redirects.ts
+++ b/test/test.redirects.ts
@@ -57,6 +57,16 @@ describe('redirects', () => {
 				return;
 			}
 
+			// Endpoint with a relative redirect destination
+			if (url.pathname === '/nested/redirect-relative') {
+				res.writeHead(301, {
+					Location: '../target?via=relative',
+					'Content-Type': 'text/html',
+				});
+				res.end('Redirecting...');
+				return;
+			}
+
 			// Target endpoint that redirects point to
 			if (url.pathname === '/target') {
 				res.writeHead(200, { 'Content-Type': 'text/html' });
@@ -238,6 +248,30 @@ describe('redirects', () => {
 				results.links[0].failureDetails &&
 					results.links[0].failureDetails.length > 0,
 				'Should have failure details',
+			);
+			const redirectError = results.links[0].failureDetails?.find(
+				(detail) => detail instanceof Error,
+			);
+			assert.strictEqual(
+				redirectError?.message,
+				`Redirect detected (${rootUrl}/redirect-301 to ${rootUrl}/target) but redirects are disabled`,
+			);
+		});
+
+		it('should resolve relative redirect destinations in error mode', async () => {
+			const originalUrl = `${rootUrl}/nested/redirect-relative`;
+			const results = await check({
+				path: originalUrl,
+				redirects: 'error',
+			});
+
+			assert.ok(!results.passed);
+			const redirectError = results.links[0].failureDetails?.find(
+				(detail) => detail instanceof Error,
+			);
+			assert.strictEqual(
+				redirectError?.message,
+				`Redirect detected (${originalUrl} to ${rootUrl}/target?via=relative) but redirects are disabled`,
 			);
 		});
 
@@ -621,10 +655,16 @@ describe('redirects', () => {
 			}
 		});
 
-		it('keeps redirects in error mode broken without processing the target', async () => {
+		it('reports the immediate destination without following a redirect chain in error mode', async () => {
 			let targetRequests = 0;
 			const errorModeServer = http.createServer((req, res) => {
 				if (req.url === '/redirect') {
+					res.writeHead(302, { Location: '/middle' });
+					res.end();
+					return;
+				}
+				if (req.url === '/middle') {
+					targetRequests++;
 					res.writeHead(302, { Location: '/target' });
 					res.end();
 					return;
@@ -649,6 +689,13 @@ describe('redirects', () => {
 				assert.strictEqual(results.links[0].state, LinkState.BROKEN);
 				assert.strictEqual(results.links[0].status, 302);
 				assert.strictEqual(targetRequests, 0);
+				const redirectError = results.links[0].failureDetails?.find(
+					(detail) => detail instanceof Error,
+				);
+				assert.strictEqual(
+					redirectError?.message,
+					`Redirect detected (${serverUrl}/redirect to ${serverUrl}/middle) but redirects are disabled`,
+				);
 			} finally {
 				errorModeServer.close();
 			}

--- a/test/test.redirects.ts
+++ b/test/test.redirects.ts
@@ -67,6 +67,20 @@ describe('redirects', () => {
 				return;
 			}
 
+			// Endpoint with an empty URI reference, which redirects back to itself
+			if (url.pathname === '/redirect-empty') {
+				res.writeHead(302, { Location: '' });
+				res.end();
+				return;
+			}
+
+			// Endpoint with a Location value that cannot be parsed as a URL
+			if (url.pathname === '/redirect-malformed') {
+				res.writeHead(302, { Location: 'http://[invalid' });
+				res.end();
+				return;
+			}
+
 			// Target endpoint that redirects point to
 			if (url.pathname === '/target') {
 				res.writeHead(200, { 'Content-Type': 'text/html' });
@@ -233,6 +247,7 @@ describe('redirects', () => {
 			// but we know a redirect happened because URL changed
 			assert.strictEqual(redirectWarnings[0].status, 200);
 			assert.strictEqual(redirectWarnings[0].isNonStandard, false);
+			assert.strictEqual(redirectWarnings[0].targetUrl, `${rootUrl}/target`);
 		});
 
 		it('should mark redirects as broken in error mode', async () => {
@@ -272,6 +287,34 @@ describe('redirects', () => {
 			assert.strictEqual(
 				redirectError?.message,
 				`Redirect detected (${originalUrl} to ${rootUrl}/target?via=relative) but redirects are disabled`,
+			);
+		});
+
+		it('should resolve an empty Location header to the current URL', async () => {
+			const originalUrl = `${rootUrl}/redirect-empty`;
+			const results = await check({ path: originalUrl, redirects: 'error' });
+
+			assert.ok(!results.passed);
+			const redirectError = results.links[0].failureDetails?.find(
+				(detail) => detail instanceof Error,
+			);
+			assert.strictEqual(
+				redirectError?.message,
+				`Redirect detected (${originalUrl} to ${originalUrl}) but redirects are disabled`,
+			);
+		});
+
+		it('should preserve a malformed Location header for diagnostics', async () => {
+			const originalUrl = `${rootUrl}/redirect-malformed`;
+			const results = await check({ path: originalUrl, redirects: 'error' });
+
+			assert.ok(!results.passed);
+			const redirectError = results.links[0].failureDetails?.find(
+				(detail) => detail instanceof Error,
+			);
+			assert.strictEqual(
+				redirectError?.message,
+				`Redirect detected (${originalUrl} to http://[invalid) but redirects are disabled`,
 			);
 		});
 
@@ -397,10 +440,12 @@ describe('redirects', () => {
 				const results = await check({ path: ntUrl, redirects: 'error' });
 				assert.ok(!results.passed);
 				assert.strictEqual(results.links[0].state, LinkState.BROKEN);
-				// Should have error message about redirect being disabled
-				assert.ok(
-					results.links[0].failureDetails &&
-						results.links[0].failureDetails.length > 0,
+				const redirectError = results.links[0].failureDetails?.find(
+					(detail) => detail instanceof Error,
+				);
+				assert.strictEqual(
+					redirectError?.message,
+					`Redirect detected (${ntUrl}) but redirects are disabled`,
 				);
 			} finally {
 				noTargetServer.close();


### PR DESCRIPTION
## Summary

- prefer the `Location` header when reporting an unfollowed 3xx redirect
- resolve relative redirect targets against the URL that produced the response
- distinguish missing `Location` headers from empty URI references and preserve malformed values for diagnostics
- continue using the final response URL for followed redirects in `warn`/`allow` modes
- add regression coverage for absolute, relative, empty, malformed, and missing targets, plus redirect chains

In `redirects: error` mode, redirects remain unfollowed. For a chain, the diagnostic therefore reports the immediate destination from `Location`, not an unobserved final destination.

Addresses JustinBeckwith/linkinator-action#286.

## Validation

- `npm test -- --run test/test.redirects.ts test/test.redirect-rewrites.ts` (34 passed)
- `npm test -- --run` (266 passed)
- `npm run lint`
- `npm run build`
- `git diff --check`