### PR TITLE
fix: recognize #top document fragments

### DIFF
--- a/src/links.ts
+++ b/src/links.ts
@@ -422,7 +422,7 @@ export async function validateFragments(
 	for (const fragment of fragmentsToValidate) {
 		results.push({
 			fragment,
-			isValid: validFragments.has(fragment),
+			isValid: /^[tT][oO][pP]$/.test(fragment) || validFragments.has(fragment),
 		});
 	}
 

--- a/test/fixtures/fragments-markdown-top/index.html
+++ b/test/fixtures/fragments-markdown-top/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Markdown Top Fragment Test</title>
+</head>
+<body>
+	<a href="target.md#top">Markdown document top</a>
+	<a href="target.md#missing">Missing Markdown target</a>
+</body>
+</html>

--- a/test/fixtures/fragments-markdown-top/target.md
+++ b/test/fixtures/fragments-markdown-top/target.md
@@ -1,0 +1,3 @@
+# Markdown document
+
+This document intentionally has no element named `top`.

--- a/test/fixtures/fragments-top/index.html
+++ b/test/fixtures/fragments-top/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Top Fragment Test</title>
+</head>
+<body>
+	<a href="#top">Same-page lowercase top</a>
+	<a href="#TOP">Same-page uppercase top</a>
+	<a href="#%74op">Same-page percent-encoded top</a>
+	<a href="#ordinary%20id">Same-page encoded existing ID</a>
+	<a href="#missing%20id">Same-page encoded missing ID</a>
+	<a href="http://example.com/target.html#ToP">Cross-page mixed-case top</a>
+	<a href="http://example.com/target.html#%74op">Cross-page percent-encoded top</a>
+	<a href="http://example.com/target.html#missing">Cross-page missing fragment</a>
+	<div id="ordinary id">Existing encoded fragment target</div>
+</body>
+</html>

--- a/test/test.fragments.ts
+++ b/test/test.fragments.ts
@@ -454,6 +454,27 @@ describe('fragment identifier validation', () => {
 		);
 	});
 
+	it('should recognize the top target while checking local Markdown', async () => {
+		const results = await check({
+			path: 'test/fixtures/fragments-markdown-top',
+			markdown: true,
+			checkFragments: true,
+		});
+
+		expect(results.passed).toBe(false);
+		expect(
+			results.links.find(
+				(link) => link.url.endsWith('#top') && link.state === LinkState.BROKEN,
+			),
+		).toBeUndefined();
+		expect(
+			results.links.find(
+				(link) =>
+					link.url.endsWith('#missing') && link.state === LinkState.BROKEN,
+			),
+		).toBeDefined();
+	});
+
 	it('should validate same-page fragment links (issue #770)', async () => {
 		const results = await check({
 			path: 'test/fixtures/fragments-same-page',
@@ -481,6 +502,79 @@ describe('fragment identifier validation', () => {
 				l.state === LinkState.BROKEN,
 		);
 		expect(validFragments).toHaveLength(0);
+	});
+
+	it('should treat top and its ASCII case variants as valid document targets', async () => {
+		const mockPool = mockAgent.get('http://example.com');
+
+		mockPool
+			.intercept({ path: '/target.html', method: 'HEAD' })
+			.reply(200, '', { headers: { 'content-type': 'text/html' } });
+
+		mockPool
+			.intercept({ path: '/target.html', method: 'GET' })
+			.reply(200, '<html><body><p>No fragment targets</p></body></html>', {
+				headers: { 'content-type': 'text/html' },
+			});
+
+		const results = await check({
+			path: 'test/fixtures/fragments-top',
+			checkFragments: true,
+		});
+
+		expect(results.passed).toBe(false);
+		expect(
+			results.links.filter(
+				(link) =>
+					/#(?:top|TOP|ToP)$/i.test(link.url) &&
+					link.state === LinkState.BROKEN,
+			),
+		).toHaveLength(0);
+		expect(
+			results.links.find(
+				(link) =>
+					link.url === 'http://example.com/target.html#missing' &&
+					link.state === LinkState.BROKEN,
+			),
+		).toBeDefined();
+		expect(
+			results.links.find(
+				(link) =>
+					link.url.endsWith('#missing id') && link.state === LinkState.BROKEN,
+			),
+		).toBeDefined();
+		expect(
+			results.links.find(
+				(link) =>
+					link.url.endsWith('#ordinary id') && link.state === LinkState.BROKEN,
+			),
+		).toBeUndefined();
+	});
+
+	it('should apply fragment skip rules before recognizing the top target', async () => {
+		const mockPool = mockAgent.get('http://example.com');
+
+		mockPool
+			.intercept({ path: '/target.html', method: 'HEAD' })
+			.reply(200, '', { headers: { 'content-type': 'text/html' } });
+
+		mockPool
+			.intercept({ path: '/target.html', method: 'GET' })
+			.reply(200, '<html><body><p>No fragment targets</p></body></html>', {
+				headers: { 'content-type': 'text/html' },
+			});
+
+		const results = await check({
+			path: 'test/fixtures/fragments-top',
+			checkFragments: true,
+			fragmentsToSkip: ['^TOP$'],
+		});
+
+		expect(
+			results.links.find(
+				(link) => link.url.endsWith('#TOP') && link.state === LinkState.SKIPPED,
+			),
+		).toBeDefined();
 	});
 
 	it('should validate GitHub-style permalink anchors', async () => {
@@ -546,6 +640,43 @@ describe('fragment identifier validation', () => {
 			const results = await validateFragments(htmlContent, fragmentsToCheck);
 
 			expect(results).toHaveLength(0);
+		});
+
+		it('should only recognize ASCII case variants of top as special', async () => {
+			const htmlContent = Buffer.from(`
+				<html>
+					<body>
+						<div id="ordinary-id">Content</div>
+						<a name="legacy-anchor">Legacy target</a>
+					</body>
+				</html>
+			`);
+			const fragmentsToCheck = new Set([
+				'top',
+				'TOP',
+				'ToP',
+				'ordinary-id',
+				'legacy-anchor',
+				'top ',
+				'töp',
+				'missing',
+			]);
+
+			const results = await validateFragments(htmlContent, fragmentsToCheck);
+			const validity = Object.fromEntries(
+				results.map(({ fragment, isValid }) => [fragment, isValid]),
+			);
+
+			expect(validity).toEqual({
+				top: true,
+				TOP: true,
+				ToP: true,
+				'ordinary-id': true,
+				'legacy-anchor': true,
+				'top ': false,
+				töp: false,
+				missing: false,
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Problem

With fragment checking enabled, Linkinator reports a broken fragment for a document-top link when the page has no element named `top`:

```html
<a href="#top">Back to top</a>
```

The HTML fragment-navigation algorithm treats the decoded fragment `top`, matched ASCII case-insensitively, as a special value that navigates to the top of the document.

## Fix

Recognize exact ASCII case variants of decoded `top` as valid in the shared fragment validator, while retaining exact `id`/`name` matching for every other fragment.

Regression coverage includes:

- lowercase, uppercase, and mixed-case `top`
- same-page and cross-page references
- percent-encoded `top`
- percent-encoded existing and missing ordinary targets
- existing `id` and legacy `name` targets
- non-ASCII and trailing-space near misses
- fragment skip-rule precedence
- local Markdown rendering and checking
- ordinary missing fragments remaining broken

## Verification

- `npm test -- --run test/test.fragments.ts` — 26 tests passed
- `npm test -- --run` — 267 tests passed
- `npm run build` — passed
- `npm run lint` — passed
- `npm run coverage` — 267 tests passed; 94.01% statements, 88.99% branches, 98% functions, 93.95% lines overall
- Changed production path: 100% statement/branch/function/line coverage (predicate statement 47 hits; OR operands 47/36 hits; validator function 19 hits)

Two independent code reviews found no actionable issues.
