### PR TITLE
fix: parse quoted meta refresh targets

### DIFF
--- a/src/links.ts
+++ b/src/links.ts
@@ -52,6 +52,7 @@ export type ParsedUrl = {
 /**
  * Parses meta refresh content to extract the URL.
  * Meta refresh format: "0;url=https://example.com" or "0; url=https://example.com"
+ * Browser processing removes an opening quote and truncates at its next match.
  * @param content The content attribute value from a meta refresh tag
  * @returns The extracted URL or null if parsing fails
  */
@@ -60,7 +61,13 @@ function parseMetaRefresh(content: string): string | null {
 	// The delay can be any number, URL parameter can have optional spaces
 	const match = content.match(/^\s*\d+\s*;\s*url\s*=\s*(.+)/i);
 	if (match?.[1]) {
-		return match[1].trim();
+		const url = match[1].trim();
+		const quote = url[0];
+		if (quote === "'" || quote === '"') {
+			const closingQuote = url.indexOf(quote, 1);
+			return url.slice(1, closingQuote === -1 ? undefined : closingQuote);
+		}
+		return url;
 	}
 	return null;
 }

--- a/test/fixtures/metarefresh/index.html
+++ b/test/fixtures/metarefresh/index.html
@@ -3,6 +3,7 @@
 <meta http-equiv="refresh" content="0;url=http://example.invalid/redirected" />
 <meta http-equiv="refresh" content="5; url=http://example.invalid/delayed" />
 <meta http-equiv="REFRESH" content="0;URL=http://example.invalid/uppercase" />
+<meta http-equiv="refresh" content="0; URL='http://example.invalid/quoted-target'" />
 </head>
 <body>
 <p>This page contains meta refresh redirects</p>

--- a/test/test.index.ts
+++ b/test/test.index.ts
@@ -992,13 +992,16 @@ describe('linkinator', () => {
 		mockPool.intercept({ path: '/redirected', method: 'HEAD' }).reply(200, '');
 		mockPool.intercept({ path: '/delayed', method: 'HEAD' }).reply(200, '');
 		mockPool.intercept({ path: '/uppercase', method: 'HEAD' }).reply(200, '');
+		mockPool
+			.intercept({ path: '/quoted-target', method: 'HEAD' })
+			.reply(200, '');
 		const results = await check({ path: 'test/fixtures/metarefresh' });
 		assert.ok(results.passed);
-		// Should find 3 meta refresh URLs
+		// Should find 4 meta refresh URLs
 		const metaRefreshLinks = results.links.filter((link) =>
 			link.url?.includes('example.invalid'),
 		);
-		assert.strictEqual(metaRefreshLinks.length, 3);
+		assert.strictEqual(metaRefreshLinks.length, 4);
 	});
 
 	it('should extract URLs from inline CSS in style attributes and tags when checkCss is enabled', async () => {

--- a/test/test.links.ts
+++ b/test/test.links.ts
@@ -1,11 +1,11 @@
 import { Readable } from 'node:stream';
-import { assert, describe, it } from 'vitest';
+import { assert, describe, expect, it } from 'vitest';
 import { getLinks } from '../src/links.js';
 
-const baseUrl = 'https://example.com/';
+const linkRelationshipBaseUrl = 'https://example.com/';
 
 async function linksFrom(html: string): Promise<string[]> {
-	const links = await getLinks(Readable.from(html), baseUrl);
+	const links = await getLinks(Readable.from(html), linkRelationshipBaseUrl);
 	return links.map((link) => link.url?.href ?? link.link);
 }
 
@@ -41,5 +41,79 @@ describe('HTML link relationships', () => {
 			'<link href="https://asset-origin.example/">',
 		);
 		assert.deepStrictEqual(links, ['https://asset-origin.example/']);
+	});
+});
+
+const metaRefreshBaseUrl = 'https://base.example/root/index.html';
+
+function metaRefresh(content: string): Readable {
+	const escapedContent = content
+		.replaceAll('&', '&amp;')
+		.replaceAll('"', '&quot;');
+	return Readable.from(
+		`<meta http-equiv="refresh" content="${escapedContent}">`,
+	);
+}
+
+describe('meta refresh links', () => {
+	it.each([
+		{
+			name: 'single-quoted root-relative URL',
+			content: "0; URL='/target'",
+			link: '/target',
+			url: 'https://base.example/target',
+		},
+		{
+			name: 'double-quoted absolute URL',
+			content: '0; URL="https://other.example/absolute"',
+			link: 'https://other.example/absolute',
+			url: 'https://other.example/absolute',
+		},
+		{
+			name: 'whitespace and mixed-case URL parameter',
+			content: "  5 ;  uRl  =  'relative/path'  ",
+			link: 'relative/path',
+			url: 'https://base.example/root/relative/path',
+		},
+		{
+			name: 'query, fragment, and semicolons inside quotes',
+			content: "0; URL='/search;path?one=1&two=2;three=3#part;four' ignored",
+			link: '/search;path?one=1&two=2;three=3#part;four',
+			url: 'https://base.example/search;path?one=1&two=2;three=3#part;four',
+		},
+		{
+			name: 'unmatched opening single quote',
+			content: "0; URL='/unmatched?q=value#fragment",
+			link: '/unmatched?q=value#fragment',
+			url: 'https://base.example/unmatched?q=value#fragment',
+		},
+		{
+			name: 'unmatched opening double quote',
+			content: '0; URL="relative-unmatched',
+			link: 'relative-unmatched',
+			url: 'https://base.example/root/relative-unmatched',
+		},
+		{
+			name: 'existing unquoted format',
+			content: '0;url=/plain;path?q=one;two#part;three',
+			link: '/plain;path?q=one;two#part;three',
+			url: 'https://base.example/plain;path?q=one;two#part;three',
+		},
+	])('extracts $name', async ({ content, link, url }) => {
+		const links = await getLinks(metaRefresh(content), metaRefreshBaseUrl);
+
+		expect(links).toHaveLength(1);
+		expect(links[0]).toMatchObject({ link, urlWithFragment: url });
+	});
+
+	it.each([
+		['missing delay', 'url=/target'],
+		['missing separator', '0 url=/target'],
+		['missing URL parameter', '0; href=/target'],
+		['missing target', '0; url='],
+	])('ignores malformed content with %s', async (_name, content) => {
+		const links = await getLinks(metaRefresh(content), metaRefreshBaseUrl);
+
+		expect(links).toEqual([]);
 	});
 });


### PR DESCRIPTION
## Problem

Linkinator retained quote characters around browser-supported meta-refresh targets. For example:

```html
<meta http-equiv="refresh" content="0; URL='/target'">
```

A browser navigates to `/target`, but Linkinator checked `/'/target'`, producing a false `BROKEN` result when the quoted path returned 404.

## Fix

After extracting the existing `delay; URL=...` form, remove an opening single or double quote and truncate the target at the next matching quote. If the opening quote is unmatched, use the remaining target, matching the HTML declarative-refresh processing algorithm.

This keeps the parser's existing accepted grammar and unquoted behavior unchanged.

## Tests

Added direct parser coverage for:

- matching single and double quotes
- whitespace and mixed-case `URL`
- absolute, root-relative, and path-relative targets
- query strings, fragments, ampersands, and semicolons inside quoted targets
- trailing text after a closing quote
- unmatched single and double quotes
- existing unquoted formats
- representative malformed inputs

The integration fixture verifies that a quoted target returning 200 is requested without its quote characters.

Verification:

- `npm test -- --run test/test.links.ts test/test.index.ts` — 98 passed
- `npm test -- --run` — 305 passed across 19 files
- `npm run build` — passed
- `npm run lint` — passed
- `npm run coverage` — 305 passed; 94.43% statements, 89.67% branches, 98.16% functions, 94.36% lines overall
- changed `parseMetaRefresh` path — 100% statement, branch, function, and line coverage (every new branch outcome has nonzero hits)

Two independent code reviews found no actionable issues and confirmed correctness, regression safety, edge-case handling, maintainability, and test completeness.
