### PR TITLE
fix: handle multiple absolute local paths

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -47,6 +47,45 @@ export type InternalCheckOptions = {
 export const DEFAULT_USER_AGENT =
 	'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
 
+/** @internal */
+export async function findCommonPathRoot(
+	paths: string[],
+	pathImplementation = path,
+): Promise<string> {
+	const filesystemRoot = pathImplementation.parse(paths[0]).root;
+	const normalizedFilesystemRoot = filesystemRoot.toLowerCase();
+	if (
+		paths.some(
+			(filePath) =>
+				pathImplementation.parse(filePath).root.toLowerCase() !==
+				normalizedFilesystemRoot,
+		)
+	) {
+		throw new Error(
+			'Absolute paths must be on the same filesystem when checked together.',
+		);
+	}
+
+	const servingRoots = await Promise.all(
+		paths.map(async (filePath) => {
+			const stats = await fs.stat(filePath);
+			return stats.isDirectory()
+				? filePath
+				: pathImplementation.dirname(filePath);
+		}),
+	);
+	let commonRoot = servingRoots[0];
+	for (const servingRoot of servingRoots.slice(1)) {
+		let relativePath = pathImplementation.relative(commonRoot, servingRoot);
+		while (relativePath.split(pathImplementation.sep)[0] === '..') {
+			commonRoot = pathImplementation.dirname(commonRoot);
+			relativePath = pathImplementation.relative(commonRoot, servingRoot);
+		}
+	}
+
+	return commonRoot;
+}
+
 /**
  * Validate the provided flags all work with each other.
  * @param options CheckOptions passed in from the CLI (or API)
@@ -166,10 +205,23 @@ export async function processOptions(
 	// Figure out which directory should be used as the root for the web server,
 	// and how that impacts the path to the file for the first request.
 	if (!options.serverRoot && !isUrlType) {
-		// If the serverRoot wasn't defined, and there are multiple paths, just
-		// use process.cwd().
+		// If any path is absolute, normalize every path and serve them relative to
+		// their nearest common directory. This keeps the local server from
+		// incorrectly looking for absolute paths beneath process.cwd().
 		if (options.path.length > 1) {
-			options.serverRoot = process.cwd();
+			if (options.path.some((filePath) => path.isAbsolute(filePath))) {
+				const absolutePaths = options.path.map((filePath) =>
+					path.resolve(filePath),
+				);
+				const serverRoot = await findCommonPathRoot(absolutePaths);
+				options.serverRoot = serverRoot;
+				options.path = absolutePaths.map((filePath) =>
+					path.relative(serverRoot, filePath),
+				);
+				options.syntheticServerRoot = options.serverRoot;
+			} else {
+				options.serverRoot = process.cwd();
+			}
 		} else {
 			// If there's a single path, try to be smart and figure it out
 			const s = await fs.stat(options.path[0]);

--- a/test/test.cli.ts
+++ b/test/test.cli.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import http from 'node:http';
 import type { AddressInfo } from 'node:net';
+import path from 'node:path';
 import util from 'node:util';
 import { execa } from 'execa';
 import stripAnsi from 'strip-ansi';
@@ -53,6 +54,15 @@ describe('cli', () => {
 			linkinator,
 			'test/fixtures/markdown/unlinked.md',
 			'test/fixtures/markdown/README.md',
+		]);
+		assert.match(response.stderr, /Successfully scanned/);
+	});
+
+	it('should allow multiple absolute paths', async () => {
+		const response = await execa(node, [
+			linkinator,
+			path.resolve('test/fixtures/srcset/_site/foo.html'),
+			path.resolve('test/fixtures/srcset/_site/bar.html'),
 		]);
 		assert.match(response.stderr, /Successfully scanned/);
 	});

--- a/test/test.index.ts
+++ b/test/test.index.ts
@@ -518,6 +518,75 @@ describe('linkinator', () => {
 		assert.strictEqual(results.links.length, 6);
 	});
 
+	it('should accept multiple absolute file paths in the same directory', async () => {
+		const inputPaths = [
+			path.resolve('test/fixtures/srcset/_site/foo.html'),
+			path.resolve('test/fixtures/srcset/_site/bar.html'),
+		];
+		const results = await check({ path: inputPaths });
+		assert.ok(results.passed);
+		assert.deepStrictEqual(
+			results.links.map((link) => link.url).sort(),
+			inputPaths.sort(),
+		);
+	});
+
+	it('should accept multiple absolute file paths in different directories', async () => {
+		const inputPaths = [
+			path.resolve('test/fixtures/relative/ohai.html'),
+			path.resolve('test/fixtures/server/test.html'),
+		];
+		const results = await check({ path: inputPaths });
+		assert.ok(results.passed);
+		assert.deepStrictEqual(
+			results.links.map((link) => link.url).sort(),
+			inputPaths.sort(),
+		);
+	});
+
+	it('should accept an absolute glob that expands to multiple files', async () => {
+		const results = await check({
+			path: path.resolve('test/fixtures/srcset/_site/*.html'),
+		});
+		assert.ok(results.passed);
+		assert.deepStrictEqual(results.links.map((link) => link.url).sort(), [
+			path.resolve('test/fixtures/srcset/_site/bar.html'),
+			path.resolve('test/fixtures/srcset/_site/foo.html'),
+		]);
+	});
+
+	it('should accept mixed absolute and relative paths after glob expansion', async () => {
+		const expectedPaths = [
+			path.resolve('test/fixtures/srcset/_site/bar.html'),
+			path.resolve('test/fixtures/srcset/_site/foo.html'),
+		];
+		const results = await check({
+			path: [expectedPaths[1], 'test/fixtures/srcset/_site/b*.html'],
+		});
+		assert.ok(results.passed);
+		assert.deepStrictEqual(
+			results.links.map((link) => link.url).sort(),
+			expectedPaths,
+		);
+	});
+
+	it('should select the same root when an absolute directory comes first or last', async () => {
+		const directoryPath = path.resolve('test/fixtures/redirect-recurse');
+		const filePath = path.join(directoryPath, 'child-one/index.html');
+		for (const inputPaths of [
+			[directoryPath, filePath],
+			[filePath, directoryPath],
+		]) {
+			const results = await check({ path: inputPaths });
+			assert.ok(results.passed);
+			assert.ok(
+				results.links.some((link) =>
+					link.url.endsWith(path.join('child-one', path.sep)),
+				),
+			);
+		}
+	});
+
 	it('should not allow mixed local and remote paths', async () => {
 		await expect(
 			check({

--- a/test/test.options.ts
+++ b/test/test.options.ts
@@ -1,0 +1,25 @@
+import path from 'node:path';
+import { assert, describe, expect, it } from 'vitest';
+import { findCommonPathRoot } from '../src/options.js';
+
+describe('options', () => {
+	it('finds the common root when one absolute path is an ancestor', async () => {
+		const directoryPath = path.resolve('test/fixtures/relative');
+		assert.strictEqual(
+			await findCommonPathRoot([
+				path.join(directoryPath, 'nested/nested.html'),
+				directoryPath,
+			]),
+			directoryPath,
+		);
+	});
+
+	it('rejects absolute paths on different Windows filesystems', async () => {
+		await expect(
+			findCommonPathRoot(
+				['C:\\workspace\\one.md', 'D:\\workspace\\two.md'],
+				path.win32,
+			),
+		).rejects.toThrow(/same filesystem/);
+	});
+});


### PR DESCRIPTION
## Problem

Checking two or more absolute local filesystem paths reported valid files as `404`/`BROKEN`:

```js
await check({ path: ['/absolute/valid/a.md', '/absolute/valid/b.md'] });
```

Multi-path option processing selected `process.cwd()` as the temporary server root while retaining each absolute path. Local URL construction then removed the leading separator, causing the server to look for every file beneath `cwd`.

## Fix

- Normalize multi-path local inputs when any expanded path is absolute.
- Derive a directory-aware, order-independent common serving root from the real input files/directories.
- Convert the starting paths to server-root-relative paths and retain the synthetic root so result URLs map back to absolute filesystem paths.
- Preserve the existing behavior for all-relative inputs and explicit `serverRoot` configurations.
- Reject absolute Windows paths spanning different filesystems with a clear error rather than constructing invalid local-server URLs.

## Regression coverage

- Public API: multiple absolute files in the same directory
- Public API: absolute files in different directories
- Public API: absolute globs expanding to multiple files
- Public API: mixed absolute/relative inputs after glob expansion
- Public API: directory/file inputs in both orders, including root-relative links
- CLI: multiple absolute paths
- Windows: cross-filesystem rejection and separator-aware common-root logic

## Verification

- `npm run lint` — passed (only the pre-existing Biome schema-version informational notice)
- `npm run build` — passed
- `npx vitest run test/test.options.ts test/test.index.ts test/test.cli.ts --coverage` — 113/113 passed
- `npm test -- --run` — 274/274 passed
- `npm run coverage` — 274/274 passed
  - overall: 94.23% statements, 89.15% branches, 98.11% functions, 94.16% lines
  - `src/options.ts`: 100% statements, functions, and lines
  - every new or changed conditional branch was exercised in both directions
- `npm pack --dry-run --json` — passed; expected compiled package contents and `build/package.json` present
- `npm run build-binaries` — Linux, Windows, and macOS binaries built successfully
- macOS standalone binary smoke test — mixed absolute/relative paths both returned `200`

Two independent code reviews approved the final diff with no remaining actionable findings.
