### PR TITLE
fix: handle tokenized HTML resource hint relationships

### DIFF
--- a/src/links.ts
+++ b/src/links.ts
@@ -31,6 +31,7 @@ const linksAttribute: Record<string, string[]> = {
 	],
 	srcset: ['img', 'source'],
 };
+const ignoredLinkRelationships = new Set(['dns-prefetch', 'preconnect']);
 // Create lookup table for tag name to attribute that contains URL:
 const tagAttribute: Record<string, string[]> = {};
 for (const attribute of Object.keys(linksAttribute)) {
@@ -96,9 +97,17 @@ export async function getLinks(
 				jsonLdContent = '';
 			}
 
-			// ignore href properties for link tags where rel is likely to fail
-			const relValuesToIgnore = ['dns-prefetch', 'preconnect'];
-			if (tag === 'link' && relValuesToIgnore.includes(attributes.rel)) {
+			// Ignore href properties only when every rel token is a resource hint
+			// that Linkinator intentionally does not validate. HTML rel values are
+			// ASCII-case-insensitive sets of tokens separated by ASCII whitespace.
+			const relTokens = attributes.rel?.match(/[^\t\n\f\r ]+/g) ?? [];
+			if (
+				tag === 'link' &&
+				relTokens.length > 0 &&
+				relTokens.every((rel) =>
+					ignoredLinkRelationships.has(rel.toLowerCase()),
+				)
+			) {
 				return;
 			}
 

--- a/test/fixtures/prefetch/index.html
+++ b/test/fixtures/prefetch/index.html
@@ -2,7 +2,10 @@
   <head>
     <link rel="dns-prefetch" href="https://fonts.gstatic.com">
     <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link rel="dns-prefetch preconnect" href="https://asset-origin.example/">
+    <link rel=" DnS-PrEfEtCh&#9;PRECONNECT&#10;" href="https://asset-origin.example/">
     <link rel="stylesheet" href="http://example.invalid/site.css">
+    <link rel="preconnect stylesheet" href="http://example.invalid/mixed.css">
   </head>
   <body></body>
 </html>

--- a/test/test.index.ts
+++ b/test/test.index.ts
@@ -450,9 +450,10 @@ describe('linkinator', () => {
 	it('should not attempt to validate preconnect or prefetch urls', async () => {
 		const mockPool = mockAgent.get('http://example.invalid');
 		mockPool.intercept({ path: '/site.css', method: 'HEAD' }).reply(200, '');
+		mockPool.intercept({ path: '/mixed.css', method: 'HEAD' }).reply(200, '');
 		const results = await check({ path: 'test/fixtures/prefetch' });
 		assert.ok(results.passed);
-		assert.strictEqual(results.links.length, 2);
+		assert.strictEqual(results.links.length, 3);
 	});
 
 	it('should attempt a GET request if a HEAD request fails on external links', async () => {

--- a/test/test.links.ts
+++ b/test/test.links.ts
@@ -1,0 +1,45 @@
+import { Readable } from 'node:stream';
+import { assert, describe, it } from 'vitest';
+import { getLinks } from '../src/links.js';
+
+const baseUrl = 'https://example.com/';
+
+async function linksFrom(html: string): Promise<string[]> {
+	const links = await getLinks(Readable.from(html), baseUrl);
+	return links.map((link) => link.url?.href ?? link.link);
+}
+
+describe('HTML link relationships', () => {
+	it.each([
+		'dns-prefetch preconnect',
+		'PRECONNECT',
+		' DnS-PrEfEtCh\tPRECONNECT\n',
+		'dns-prefetch\fpreconnect\rdns-prefetch',
+	])('ignores href when all rel tokens are resource hints: %j', async (rel) => {
+		const links = await linksFrom(
+			`<link rel="${rel}" href="https://asset-origin.example/">`,
+		);
+		assert.deepStrictEqual(links, []);
+	});
+
+	it.each([
+		'stylesheet',
+		'preconnect stylesheet',
+		'dns-prefetch\tSTYLESHEET preconnect',
+		'',
+		'   \t\n\f\r',
+		'dns-prefetch\u00a0preconnect',
+	])('validates href when rel has a checkable relationship: %j', async (rel) => {
+		const links = await linksFrom(
+			`<link rel="${rel}" href="https://asset-origin.example/">`,
+		);
+		assert.deepStrictEqual(links, ['https://asset-origin.example/']);
+	});
+
+	it('validates href when rel is omitted', async () => {
+		const links = await linksFrom(
+			'<link href="https://asset-origin.example/">',
+		);
+		assert.deepStrictEqual(links, ['https://asset-origin.example/']);
+	});
+});


### PR DESCRIPTION
## Problem

Linkinator skipped HTML resource hints only when the complete `rel` attribute exactly matched `dns-prefetch` or `preconnect`.

Valid HTML such as:

```html
<link rel="dns-prefetch preconnect" href="https://asset-origin.example/">
```

was therefore fetched and could be reported as broken when the hinted origin root returned an error. Values with different ASCII casing had the same problem.

## Fix

- Parse `rel` as an HTML token set using the five ASCII whitespace characters.
- Compare relationship tokens case-insensitively.
- Skip the `href` only when the non-empty token set consists entirely of the intentionally ignored `dns-prefetch` and `preconnect` hints.
- Continue validating mixed relationships such as `preconnect stylesheet`, as well as empty, omitted, unknown, or non-ASCII-whitespace-separated values.

## Verification

- `npm test -- --run test/test.links.ts test/test.index.ts` — 81 passed
- `npm test -- --run` — 277 passed
- `npm run build` — passed
- `npm run lint` — passed (the existing Biome schema-version informational notice remains)
- `npm run coverage` — 277 passed
  - Statements: 94.08% (779/828)
  - Branches: 89.08% (563/632)
  - Functions: 98.01% (99/101)
  - Lines: 94.01% (770/819)
  - Every added/changed statement, branch outcome, function, and line is covered.

Two independent code reviews found no actionable correctness, regression, edge-case, maintainability, or test-completeness issues.
