### PR TITLE
fix: honor configured CLI user agent

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -169,6 +169,7 @@ const cli = meow(
 			retryErrorsJitter: { type: 'number', default: 3000 },
 			urlRewriteSearch: { type: 'string' },
 			urlReWriteReplace: { type: 'string' },
+			userAgent: { type: 'string' },
 			header: { type: 'string', shortFlag: 'h', isMultiple: true },
 		},
 		booleanDefault: undefined,
@@ -369,6 +370,7 @@ async function main() {
 		retryErrors: flags.retryErrors,
 		retryErrorsCount: Number(flags.retryErrorsCount),
 		retryErrorsJitter: Number(flags.retryErrorsJitter),
+		userAgent: flags.userAgent,
 		headers,
 	};
 	if (flags.skip) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,7 @@ export type Flags = {
 	retryErrorsJitter?: number;
 	urlRewriteSearch?: string;
 	urlRewriteReplace?: string;
+	userAgent?: string;
 	urlRewriteExpressions?: Array<{
 		pattern: string | RegExp;
 		replacement: string;

--- a/src/options.ts
+++ b/src/options.ts
@@ -94,16 +94,26 @@ export async function processOptions(
 		);
 	}
 
-	// Only set User-Agent if explicitly provided by user
-	// Using Node.js's default "node" User-Agent works better with modern sites
-	// that have bot detection (they may redirect browser UAs into auth loops)
-	if (options.userAgent) {
+	const headers = options.headers ?? {};
+	if (
+		Object.keys(headers).some((name) => name.toLowerCase() === 'user-agent')
+	) {
+		options.headers = Object.fromEntries(
+			Object.entries(headers).map(([name, value]) => [
+				name.toLowerCase() === 'user-agent' ? 'User-Agent' : name,
+				value,
+			]),
+		);
+	} else if (options.userAgent) {
+		// Only set User-Agent if explicitly provided by user. Using Node.js's
+		// default "node" User-Agent works better with modern sites that have bot
+		// detection (they may redirect browser UAs into auth loops).
 		options.headers = {
 			'User-Agent': options.userAgent,
-			...(options.headers ?? {}),
+			...headers,
 		};
 	} else {
-		options.headers = options.headers ?? {};
+		options.headers = headers;
 	}
 	options.serverRoot &&= path.normalize(options.serverRoot);
 

--- a/test/fixtures/config/linkinator.config.cjs
+++ b/test/fixtures/config/linkinator.config.cjs
@@ -5,4 +5,6 @@ module.exports = {
 	concurrency: 17,
 	skip: '🌊',
 	directoryListing: false,
+	userAgent: 'ConfigCrawler/8.8',
+	header: ['X-Config-Header:preserved'],
 };

--- a/test/fixtures/config/linkinator.config.js
+++ b/test/fixtures/config/linkinator.config.js
@@ -5,4 +5,6 @@ export default {
 	concurrency: 17,
 	skip: '🌛',
 	directoryListing: false,
+	userAgent: 'ConfigCrawler/8.8',
+	header: ['X-Config-Header:preserved'],
 };

--- a/test/fixtures/config/linkinator.config.json
+++ b/test/fixtures/config/linkinator.config.json
@@ -5,5 +5,7 @@
   "concurrency": 17,
   "skip": "🌳",
   "skipFragment": ["^code/", "^!/"],
-  "directoryListing": false
+  "directoryListing": false,
+  "userAgent": "ConfigCrawler/8.8",
+  "header": ["X-Config-Header:preserved"]
 }

--- a/test/fixtures/config/linkinator.config.mjs
+++ b/test/fixtures/config/linkinator.config.mjs
@@ -5,4 +5,6 @@ export default {
 	concurrency: 17,
 	skip: '🪐',
 	directoryListing: false,
+	userAgent: 'ConfigCrawler/8.8',
+	header: ['X-Config-Header:preserved'],
 };

--- a/test/test.cli.ts
+++ b/test/test.cli.ts
@@ -296,6 +296,118 @@ describe('cli', () => {
 		assert.strictEqual(response.exitCode, 0);
 	});
 
+	describe('user agent', () => {
+		async function listenForUserAgent(expectedUserAgent: string) {
+			const receivedHeaders: http.IncomingHttpHeaders[] = [];
+			server = http.createServer((request, response) => {
+				receivedHeaders.push(request.headers);
+				response.writeHead(
+					request.headers['user-agent'] === expectedUserAgent ? 200 : 403,
+				);
+				response.end();
+			});
+			await new Promise<void>((resolve) => server.listen(0, resolve));
+			const address = server.address() as AddressInfo;
+			return {
+				receivedHeaders,
+				url: `http://localhost:${address.port}`,
+			};
+		}
+
+		it('should send the user agent provided on the CLI', async () => {
+			const expectedUserAgent = 'ExpectedCrawler/9.9';
+			const { receivedHeaders, url } =
+				await listenForUserAgent(expectedUserAgent);
+
+			const response = await execa(node, [
+				linkinator,
+				url,
+				'--user-agent',
+				expectedUserAgent,
+			]);
+
+			assert.strictEqual(response.exitCode, 0);
+			assert.deepStrictEqual(
+				receivedHeaders.map((headers) => headers['user-agent']),
+				[expectedUserAgent],
+			);
+		});
+
+		it('should send userAgent and custom headers from every config format', async () => {
+			const expectedUserAgent = 'ConfigCrawler/8.8';
+			const { receivedHeaders, url } =
+				await listenForUserAgent(expectedUserAgent);
+			const configs = [
+				'test/fixtures/config/linkinator.config.json',
+				'test/fixtures/config/linkinator.config.js',
+				'test/fixtures/config/linkinator.config.mjs',
+				'test/fixtures/config/linkinator.config.cjs',
+			];
+
+			for (const config of configs) {
+				const response = await execa(node, [
+					linkinator,
+					url,
+					'--config',
+					config,
+				]);
+				assert.strictEqual(response.exitCode, 0);
+			}
+
+			assert.deepStrictEqual(
+				receivedHeaders.map((headers) => ({
+					userAgent: headers['user-agent'],
+					customHeader: headers['x-config-header'],
+				})),
+				configs.map(() => ({
+					userAgent: expectedUserAgent,
+					customHeader: 'preserved',
+				})),
+			);
+		});
+
+		it('should prefer the CLI user agent over config', async () => {
+			const expectedUserAgent = 'CliCrawler/7.7';
+			const { receivedHeaders, url } =
+				await listenForUserAgent(expectedUserAgent);
+
+			const response = await execa(node, [
+				linkinator,
+				url,
+				'--config',
+				'test/fixtures/config/linkinator.config.json',
+				'--user-agent',
+				expectedUserAgent,
+			]);
+
+			assert.strictEqual(response.exitCode, 0);
+			assert.strictEqual(receivedHeaders[0]['user-agent'], expectedUserAgent);
+		});
+
+		it('should preserve User-Agent header overrides case-insensitively', async () => {
+			const expectedUserAgent = 'HeaderCrawler/6.6';
+			const { receivedHeaders, url } =
+				await listenForUserAgent(expectedUserAgent);
+
+			for (const headerName of ['User-Agent', 'user-agent', 'uSeR-aGeNt']) {
+				const response = await execa(node, [
+					linkinator,
+					url,
+					'--user-agent',
+					'FlagCrawler/5.5',
+					'--header',
+					`${headerName}:${expectedUserAgent}`,
+				]);
+				assert.strictEqual(response.exitCode, 0);
+			}
+
+			assert.deepStrictEqual(
+				receivedHeaders.map((headers) => headers['user-agent']),
+				[expectedUserAgent, expectedUserAgent, expectedUserAgent],
+			);
+		});
+	});
+
 	it('should fail if a url search is provided without a replacement', async () => {
 		const response = await execa(
 			node,

--- a/test/test.config.ts
+++ b/test/test.config.ts
@@ -94,6 +94,8 @@ describe('config', () => {
 				concurrency: 17,
 				skip: '🌛',
 				directoryListing: false,
+				userAgent: 'ConfigCrawler/8.8',
+				header: ['X-Config-Header:preserved'],
 			};
 			delete actualConfig.config;
 
@@ -112,6 +114,8 @@ describe('config', () => {
 				concurrency: 17,
 				skip: '🌛',
 				directoryListing: false,
+				userAgent: 'ConfigCrawler/8.8',
+				header: ['X-Config-Header:preserved'],
 			};
 			delete actualConfig.config;
 
@@ -130,6 +134,8 @@ describe('config', () => {
 				concurrency: 17,
 				skip: '🪐',
 				directoryListing: false,
+				userAgent: 'ConfigCrawler/8.8',
+				header: ['X-Config-Header:preserved'],
 			};
 			delete actualConfig.config;
 
@@ -148,6 +154,8 @@ describe('config', () => {
 				concurrency: 17,
 				skip: '🪐',
 				directoryListing: false,
+				userAgent: 'ConfigCrawler/8.8',
+				header: ['X-Config-Header:preserved'],
 			};
 			delete actualConfig.config;
 
@@ -166,6 +174,8 @@ describe('config', () => {
 				concurrency: 17,
 				skip: '🌊',
 				directoryListing: false,
+				userAgent: 'ConfigCrawler/8.8',
+				header: ['X-Config-Header:preserved'],
 			};
 			delete actualConfig.config;
 
@@ -185,6 +195,8 @@ describe('config', () => {
 				concurrency: 17,
 				skip: '🌊',
 				directoryListing: false,
+				userAgent: 'ConfigCrawler/8.8',
+				header: ['X-Config-Header:preserved'],
 			};
 			delete actualConfig.config;
 

--- a/test/test.index.ts
+++ b/test/test.index.ts
@@ -782,6 +782,28 @@ describe('linkinator', () => {
 		assert.ok(results.passed);
 	});
 
+	it('should apply custom User-Agent headers case-insensitively', async () => {
+		const mockPool = mockAgent.get('http://example.invalid');
+		mockPool
+			.intercept({
+				path: '/',
+				method: 'HEAD',
+				headers: (headers) =>
+					headers['user-agent'] === 'HeaderCrawler/6.6' &&
+					headers['x-custom'] === 'preserved',
+			})
+			.reply(200, '');
+		const results = await check({
+			path: 'test/fixtures/basic',
+			userAgent: 'OptionCrawler/5.5',
+			headers: {
+				'uSeR-aGeNt': 'HeaderCrawler/6.6',
+				'X-Custom': 'preserved',
+			},
+		});
+		assert.ok(results.passed);
+	});
+
 	it('should surface call stacks on failures in the API', async () => {
 		const results = await check({
 			path: 'http://example.invalid',


### PR DESCRIPTION
## Problem

The documented `--user-agent` CLI option was omitted from meow's flag declarations and never copied into `CheckOptions`. The same handoff also dropped `userAgent` values loaded from config files.

As a result, a server that requires a specific crawler identity returned a false broken-link result:

```sh
linkinator URL --user-agent ExpectedCrawler/9.9
```

The request sent `User-Agent: node`, the endpoint returned 403, and Linkinator exited 1.

## Fix

- declare `--user-agent` and carry the merged CLI/config value into `CheckOptions`
- add `userAgent` to the CLI config type so JSON, JS, MJS, and CJS configs retain it
- canonicalize explicit `User-Agent` headers case-insensitively so header overrides remain exact instead of being comma-joined by Undici
- add wire-level request-observation coverage for the CLI flag, every config format, CLI-over-config precedence, custom-header merging, and exact/lower/mixed-case header overrides
- add API wire coverage for mixed-case header overrides to prevent a library regression

## Verification

- `npx vitest run test/test.cli.ts test/test.config.ts test/test.index.ts` — 123 passed
- `npm test -- --run` — 271 passed
- `npm run build` — passed
- `npm run lint` — passed (only the existing Biome schema-version informational notice)
- `npm run coverage` — 271 passed; 94.10% statements, 89.06% branches, 98.03% functions, 94.03% lines overall
- changed `options.ts` paths — 100% statements/functions/lines, with every added branch exercised
- inherited raw V8 child-process coverage — both changed generated CLI lines executed in all 9 focused subprocesses (2/2 lines, 100%; no new CLI branches/functions)

Two independent code reviews examined correctness, regressions, edge cases, maintainability, and test completeness. One identified the case-insensitive header edge case and one identified the CLI child-process coverage attribution gap; both were addressed, and both reviewers re-reviewed the amended diff with no remaining actionable findings.
