### PR TITLE
feat: include anchor display text in results

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,8 @@ jobs:
         node: [22, 24, 26]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ matrix.node }}

--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ Constructor method that can be used to create a new `LinkChecker` instance.  Thi
 - `pagestart` (string) - Provides the url that the crawler has just started to scan.
 - `link` (object) - Provides an object with
   - `url` (string) - The url that was scanned
+  - `displayText` (string, optional) - The normalized text content of the source `<a>` element. This is omitted for the initial URL and links discovered outside anchor elements.
   - `state` (string) - The result of the scan.  Potential values include `BROKEN`, `OK`, or `SKIPPED`.
   - `status` (number) - The HTTP status code of the request.
 
@@ -513,6 +514,7 @@ async function simple() {
   //     },
   //     {
   //       url: 'http://www.iana.org/domains/example',
+  //       displayText: 'More information...',
   //       status: 200,
   //       state: 'OK'
   //     }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	},
 	"scripts": {
 		"prepare": "husky && npm run build",
-		"coverage": "vitest run --coverage",
+		"coverage": "vitest run --coverage && node scripts/check-patch-coverage.mjs",
 		"build": "tsc -p .",
 		"build-binaries": "bun build ./build/src/cli.js --compile --minify --sourcemap --target=bun --outfile ./build/binaries/linkinator-linux && bun build ./build/src/cli.js --compile --minify --sourcemap --target=bun-windows --outfile ./build/binaries/linkinator-win.exe && bun build ./build/src/cli.js --compile --minify --sourcemap --target=bun-darwin --outfile ./build/binaries/linkinator-macos",
 		"test": "vitest",

--- a/scripts/check-patch-coverage.mjs
+++ b/scripts/check-patch-coverage.mjs
@@ -1,0 +1,150 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const workspace = process.cwd();
+
+function git(...args) {
+	return execFileSync('git', args, {
+		cwd: workspace,
+		encoding: 'utf8',
+		stdio: ['ignore', 'pipe', 'ignore'],
+	}).trim();
+}
+
+function resolveBase() {
+	if (process.argv[2]) {
+		return process.argv[2];
+	}
+	if (process.env.COVERAGE_BASE) {
+		return process.env.COVERAGE_BASE;
+	}
+	if (process.env.GITHUB_EVENT_NAME === 'push') {
+		return 'HEAD^';
+	}
+
+	const branch = process.env.GITHUB_BASE_REF || 'main';
+	try {
+		return git('merge-base', 'HEAD', `origin/${branch}`);
+	} catch {
+		return 'HEAD^';
+	}
+}
+
+function parseAddedLines(diff) {
+	const files = new Map();
+	let file;
+	let newLine = 0;
+
+	for (const line of diff.split('\n')) {
+		if (line.startsWith('+++ b/')) {
+			file = line.slice(6);
+			if (file.startsWith('src/') && file.endsWith('.ts')) {
+				files.set(file, new Set());
+			} else {
+				file = undefined;
+			}
+			continue;
+		}
+
+		const hunk = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+		if (hunk) {
+			newLine = Number(hunk[1]);
+			continue;
+		}
+		if (!file || line.startsWith('---')) {
+			continue;
+		}
+		if (line.startsWith('+')) {
+			files.get(file)?.add(newLine);
+			newLine++;
+		} else if (!line.startsWith('-')) {
+			newLine++;
+		}
+	}
+
+	return files;
+}
+
+const coveragePath = path.join(workspace, 'coverage', 'coverage-final.json');
+if (!fs.existsSync(coveragePath)) {
+	throw new Error(`Coverage data not found at ${coveragePath}`);
+}
+
+const base = resolveBase();
+const addedLines = parseAddedLines(
+	git('diff', '--unified=0', base, '--', 'src'),
+);
+const coverage = JSON.parse(fs.readFileSync(coveragePath, 'utf8'));
+let failed = false;
+
+for (const [relativeFile, lines] of addedLines) {
+	const absoluteFile = path.join(workspace, relativeFile);
+	const fileCoverage = coverage[absoluteFile];
+	if (!fileCoverage) {
+		console.error(`${relativeFile}: no coverage data found`);
+		failed = true;
+		continue;
+	}
+
+	const statements = Object.entries(fileCoverage.statementMap).filter(
+		([, statement]) => lines.has(statement.start.line),
+	);
+	const functions = Object.entries(fileCoverage.fnMap).filter(([, fn]) =>
+		lines.has(fn.loc.start.line),
+	);
+	const branches = Object.entries(fileCoverage.branchMap).filter(
+		([, branch]) =>
+			lines.has(branch.loc.start.line) ||
+			branch.locations.some((location) => lines.has(location.start.line)),
+	);
+
+	const uncoveredStatements = statements
+		.filter(([id]) => fileCoverage.s[id] === 0)
+		.map(([, statement]) => statement.start.line);
+	const uncoveredFunctions = functions
+		.filter(([id]) => fileCoverage.f[id] === 0)
+		.map(([, fn]) => fn.loc.start.line);
+	const uncoveredBranches = branches.flatMap(([id, branch]) =>
+		fileCoverage.b[id].flatMap((count, index) =>
+			count === 0
+				? [{ index, line: branch.locations[index]?.start.line ?? branch.loc.start.line }]
+				: [],
+		),
+	);
+	const branchCount = branches.reduce(
+		(total, [id]) => total + fileCoverage.b[id].length,
+		0,
+	);
+
+	console.log(
+		`${relativeFile}: ` +
+			`${statements.length - uncoveredStatements.length}/${statements.length} statements, ` +
+			`${branchCount - uncoveredBranches.length}/${branchCount} branches, ` +
+			`${functions.length - uncoveredFunctions.length}/${functions.length} functions`,
+	);
+	if (
+		uncoveredStatements.length > 0 ||
+		uncoveredBranches.length > 0 ||
+		uncoveredFunctions.length > 0
+	) {
+		console.error(
+			JSON.stringify({
+				file: relativeFile,
+				uncoveredStatements,
+				uncoveredBranches,
+				uncoveredFunctions,
+			}),
+		);
+		failed = true;
+	}
+}
+
+if (addedLines.size === 0) {
+	console.log(`No changed production TypeScript files relative to ${base}.`);
+} else if (!failed) {
+	console.log(`Patch coverage is 100% relative to ${base}.`);
+}
+
+process.exitCode = failed ? 1 : 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -256,7 +256,16 @@ type FragmentCandidate = {
 
 type FragmentContext = Pick<
 	CrawlOptions,
-	'checkOptions' | 'fragmentPages' | 'fragmentReferences' | 'results'
+	| 'checkOptions'
+	| 'fragmentPages'
+	| 'fragmentReferences'
+	| 'requestLimiter'
+	| 'retry'
+	| 'retryErrors'
+	| 'retryErrorsCount'
+	| 'retryErrorsJitter'
+	| 'results'
+	| 'signal'
 >;
 
 function withDisplayText(result: LinkResult, displayText?: string): LinkResult {
@@ -367,6 +376,10 @@ export class LinkChecker extends EventEmitter {
 		});
 		const requestLimiter = new RequestLimiter(options.concurrency || 100);
 		const runController = new AbortController();
+		const retry = Boolean(options_.retry);
+		const retryErrors = Boolean(options_.retryErrors);
+		const retryErrorsCount = options_.retryErrorsCount ?? 5;
+		const retryErrorsJitter = options_.retryErrorsJitter ?? 3000;
 
 		const results: LinkResult[] = [];
 		const initCache = new Set<string>();
@@ -405,10 +418,10 @@ export class LinkChecker extends EventEmitter {
 				retryErrorsCache,
 				queue,
 				rootPath: target.rootPath,
-				retry: Boolean(options_.retry),
-				retryErrors: Boolean(options_.retryErrors),
-				retryErrorsCount: options_.retryErrorsCount ?? 5,
-				retryErrorsJitter: options_.retryErrorsJitter ?? 3000,
+				retry,
+				retryErrors,
+				retryErrorsCount,
+				retryErrorsJitter,
 				requestLimiter,
 				signal: runController.signal,
 			});
@@ -437,17 +450,21 @@ export class LinkChecker extends EventEmitter {
 		}
 
 		await queue.onIdle();
-		this.enqueueRemainingFragmentChecks(
+		await this.checkRemainingFragments(
 			{
 				checkOptions: options,
 				fragmentPages,
 				fragmentReferences,
+				requestLimiter,
+				retry,
+				retryErrors,
+				retryErrorsCount,
+				retryErrorsJitter,
 				results,
+				signal: runController.signal,
 			},
 			fragmentCandidates,
-			queue,
 		);
-		await queue.onIdle();
 
 		const result = {
 			links: results,
@@ -1074,6 +1091,7 @@ export class LinkChecker extends EventEmitter {
 			const preferredDisplayTextByUrl = new Map<string, string>();
 			const fallbackDisplayTextByUrl = new Map<string, string>();
 			const preferredDisplayTextByFragment = new Map<string, string>();
+			const urlsWithUnskippedOccurrences = new Set<string>();
 			for (const result of urlResults) {
 				if (!result.url) {
 					continue;
@@ -1113,6 +1131,7 @@ export class LinkChecker extends EventEmitter {
 					skippedFragmentResults.add(result);
 					continue;
 				}
+				urlsWithUnskippedOccurrences.add(result.url.href);
 				if (result.displayText === undefined) {
 					continue;
 				}
@@ -1157,7 +1176,9 @@ export class LinkChecker extends EventEmitter {
 				}
 				const preferredDisplayText =
 					preferredDisplayTextByUrl.get(result.url.href) ??
-					fallbackDisplayTextByUrl.get(result.url.href);
+					(urlsWithUnskippedOccurrences.has(result.url.href)
+						? undefined
+						: fallbackDisplayTextByUrl.get(result.url.href));
 
 				// Requests are deduplicated by the fragmentless URL, but skip rules
 				// should see the complete URL as it appeared in the document.
@@ -1322,11 +1343,10 @@ export class LinkChecker extends EventEmitter {
 		await drainStream(response?.body);
 	}
 
-	private enqueueRemainingFragmentChecks(
+	private async checkRemainingFragments(
 		context: FragmentContext,
 		fragmentCandidates: Map<string, FragmentCandidate>,
-		queue: Queue,
-	): void {
+	): Promise<void> {
 		const redirectMode =
 			context.checkOptions.redirects === 'error' ? 'manual' : 'follow';
 		const processRedirectTarget =
@@ -1343,45 +1363,112 @@ export class LinkChecker extends EventEmitter {
 			processRedirectTarget,
 		} as const;
 
+		const checks: Array<Promise<void>> = [];
 		for (const url of context.fragmentReferences.keys()) {
 			const candidate = fragmentCandidates.get(url);
 			if (!candidate || candidate.state !== LinkState.OK || !candidate.isHtml) {
 				continue;
 			}
 
-			queue.add(async () => {
-				let response: RequestResponse | undefined;
-				try {
-					response = await makeRequest('GET', url, requestOptions);
-					if (
-						response.redirectSkipped ||
-						response.status < 200 ||
-						response.status >= 300 ||
-						!response.body ||
-						!isHtml(response)
-					) {
-						context.fragmentReferences.delete(url);
-						return;
-					}
+			checks.push(
+				context.requestLimiter.run(context.signal, (pause) =>
+					this.cacheRemainingFragmentPage(context, url, requestOptions, pause),
+				),
+			);
+		}
+		await Promise.all(checks);
+	}
 
-					const htmlContent = await bufferStream(toNodeReadable(response.body));
-					const htmlString = htmlContent.toString('utf-8');
-					const isSoft404 =
-						htmlString.includes('content="noindex') &&
-						htmlString.includes('nofollow');
-					await this.cacheFragmentPage(
-						context,
-						url,
-						htmlContent,
-						response.status,
-						!isSoft404,
-					);
-				} catch {
-					context.fragmentReferences.delete(url);
-				} finally {
-					await drainStream(response?.body);
+	private async cacheRemainingFragmentPage(
+		context: FragmentContext,
+		url: string,
+		requestOptions: Parameters<typeof makeRequest>[2],
+		pauseLimiter: <R>(wait: () => Promise<R>) => Promise<R>,
+	): Promise<void> {
+		let errorRetries = 0;
+		for (;;) {
+			let response: RequestResponse | undefined;
+			try {
+				response = await makeRequest('GET', url, {
+					...requestOptions,
+					signal: context.signal,
+				});
+
+				const retryAfterRaw = response.headers['retry-after'];
+				if (context.retry && response.status === 429 && retryAfterRaw) {
+					const retryAt = this.parseRetryAfter(retryAfterRaw);
+					if (!Number.isNaN(retryAt)) {
+						const retryDelay = Math.max(0, retryAt - Date.now());
+						await drainStream(response.body);
+						this.emit('retry', {
+							url,
+							status: response.status,
+							secondsUntilRetry: Math.round(retryDelay / 1000),
+						} satisfies RetryInfo);
+						await pauseLimiter(() => waitForRetry(retryDelay, context.signal));
+						continue;
+					}
 				}
-			});
+
+				if (
+					context.retryErrors &&
+					(response.status >= 500 || response.status === 429) &&
+					errorRetries < context.retryErrorsCount
+				) {
+					errorRetries++;
+					const retryDelay =
+						2 ** errorRetries * 1000 +
+						Math.random() * context.retryErrorsJitter;
+					await drainStream(response.body);
+					this.emit('retry', {
+						url,
+						status: response.status,
+						secondsUntilRetry: Math.round(retryDelay / 1000),
+					} satisfies RetryInfo);
+					await pauseLimiter(() => waitForRetry(retryDelay, context.signal));
+					continue;
+				}
+
+				if (
+					response.redirectSkipped ||
+					response.status < 200 ||
+					response.status >= 300 ||
+					!response.body ||
+					!isHtml(response)
+				) {
+					await drainStream(response.body);
+					context.fragmentReferences.delete(url);
+					return;
+				}
+
+				const htmlContent = await bufferStream(toNodeReadable(response.body));
+				const htmlString = htmlContent.toString('utf-8');
+				const isSoft404 =
+					htmlString.includes('content="noindex') &&
+					htmlString.includes('nofollow');
+				await this.cacheFragmentPage(
+					context,
+					url,
+					htmlContent,
+					response.status,
+					!isSoft404,
+				);
+				return;
+			} catch {
+				if (!context.retryErrors || errorRetries >= context.retryErrorsCount) {
+					context.fragmentReferences.delete(url);
+					return;
+				}
+				errorRetries++;
+				const retryDelay =
+					2 ** errorRetries * 1000 + Math.random() * context.retryErrorsJitter;
+				this.emit('retry', {
+					url,
+					status: 0,
+					secondsUntilRetry: Math.round(retryDelay / 1000),
+				} satisfies RetryInfo);
+				await pauseLimiter(() => waitForRetry(retryDelay, context.signal));
+			}
 		}
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,12 @@ import type { AddressInfo } from 'node:net';
 import * as path from 'node:path';
 import process from 'node:process';
 import { Readable } from 'node:stream';
-import { extractFragmentIds, getCssLinks, getLinks } from './links.js';
+import {
+	extractFragmentIds,
+	getCssLinks,
+	getLinks,
+	isValidFragment,
+} from './links.js';
 import {
 	type CheckOptions,
 	type InternalCheckOptions,
@@ -1398,7 +1403,7 @@ export class LinkChecker extends EventEmitter {
 		}
 
 		for (const [fragment, references] of fragmentsToValidate) {
-			if (!validFragments.has(fragment)) {
+			if (!isValidFragment(fragment, validFragments)) {
 				for (const reference of references.values()) {
 					this.recordBrokenFragment(context, url, fragment, status, reference);
 				}
@@ -1447,7 +1452,7 @@ export class LinkChecker extends EventEmitter {
 		if (fragmentPage) {
 			if (
 				fragmentPage.validFragments &&
-				!fragmentPage.validFragments.has(fragment)
+				!isValidFragment(fragment, fragmentPage.validFragments)
 			) {
 				this.recordBrokenFragment(
 					options,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,8 @@ import type * as http from 'node:http';
 import type { AddressInfo } from 'node:net';
 import * as path from 'node:path';
 import process from 'node:process';
-import { getCssLinks, getLinks, validateFragments } from './links.js';
+import { Readable } from 'node:stream';
+import { extractFragmentIds, getCssLinks, getLinks } from './links.js';
 import {
 	type CheckOptions,
 	type InternalCheckOptions,
@@ -60,6 +61,7 @@ export type StatusCodeWarning = {
 
 export type LinkResult = {
 	url: string;
+	displayText?: string;
 	status?: number;
 	state: LinkState;
 	parent?: string;
@@ -73,11 +75,16 @@ export type CrawlResult = {
 
 type CrawlOptions = {
 	url: URL;
+	displayText?: string;
 	parent?: string;
 	crawl: boolean;
 	results: LinkResult[];
 	cache: Set<string>;
 	relationshipCache: Set<string>;
+	fragmentReferences: Map<string, Map<string, Map<string, FragmentReference>>>;
+	fragmentRelationshipCache: Set<string>;
+	fragmentPages: Map<string, FragmentPage>;
+	fragmentCandidates: Map<string, FragmentCandidate>;
 	pendingChecks: Map<string, Promise<void>>;
 	delayCache: Map<string, number>;
 	retryErrorsCache: Map<string, number>;
@@ -227,13 +234,37 @@ async function waitForRetry(milliseconds: number, signal: AbortSignal) {
 	});
 }
 
+type FragmentReference = {
+	displayText?: string;
+	parent: string;
+};
+
+type FragmentPage = {
+	validFragments?: Set<string>;
+	status: number;
+};
+
+type FragmentCandidate = {
+	isHtml: boolean;
+	state: LinkState;
+};
+
+type FragmentContext = Pick<
+	CrawlOptions,
+	'checkOptions' | 'fragmentPages' | 'fragmentReferences' | 'results'
+>;
+
+function withDisplayText(result: LinkResult, displayText?: string): LinkResult {
+	if (displayText !== undefined) {
+		result.displayText = displayText;
+	}
+	return result;
+}
+
 /**
  * Instance class used to perform a crawl job.
  */
 export class LinkChecker extends EventEmitter {
-	// Track which fragments need to be checked for each URL
-	private fragmentsToCheck = new Map<string, Set<string>>();
-
 	/**
 	 * Register a crawl as pending, then start it only after the queue grants a
 	 * concurrency slot. The separate completion promise lets duplicate links
@@ -335,6 +366,13 @@ export class LinkChecker extends EventEmitter {
 		const results: LinkResult[] = [];
 		const initCache = new Set<string>();
 		const relationshipCache = new Set<string>();
+		const fragmentReferences = new Map<
+			string,
+			Map<string, Map<string, FragmentReference>>
+		>();
+		const fragmentRelationshipCache = new Set<string>();
+		const fragmentPages = new Map<string, FragmentPage>();
+		const fragmentCandidates = new Map<string, FragmentCandidate>();
 		const pendingChecks = new Map<string, Promise<void>>();
 		const delayCache = new Map<string, number>();
 		const retryErrorsCache = new Map<string, number>();
@@ -353,6 +391,10 @@ export class LinkChecker extends EventEmitter {
 				results,
 				cache: initCache,
 				relationshipCache,
+				fragmentReferences,
+				fragmentRelationshipCache,
+				fragmentPages,
+				fragmentCandidates,
 				pendingChecks,
 				delayCache,
 				retryErrorsCache,
@@ -389,6 +431,17 @@ export class LinkChecker extends EventEmitter {
 			}
 		}
 
+		await queue.onIdle();
+		this.enqueueRemainingFragmentChecks(
+			{
+				checkOptions: options,
+				fragmentPages,
+				fragmentReferences,
+				results,
+			},
+			fragmentCandidates,
+			queue,
+		);
 		await queue.onIdle();
 
 		const result = {
@@ -790,31 +843,6 @@ export class LinkChecker extends EventEmitter {
 			}
 		}
 
-		// If we need to check fragments and we used HEAD, we need to do a GET
-		// to get the HTML body for parsing fragment IDs
-		if (
-			options.checkOptions.checkFragments &&
-			response !== undefined &&
-			isHtml(response) &&
-			!response.body
-		) {
-			const fragmentsToCheck = this.fragmentsToCheck.get(options.url.href);
-			if (fragmentsToCheck && fragmentsToCheck.size > 0) {
-				try {
-					response = await makeRequest('GET', options.url.href, requestOptions);
-					if (response.redirectSkipped) {
-						this.recordSkippedResult(options);
-						return;
-					}
-					if (response !== undefined) {
-						status = response.status;
-					}
-				} catch (error) {
-					failures.push(error as Error);
-				}
-			}
-		}
-
 		// If retryErrors is enabled, retry 5xx and 0 status (which indicates
 		// a network error likely occurred) or 429 without retry-after data:
 		if (options.signal.aborted) {
@@ -949,15 +977,22 @@ export class LinkChecker extends EventEmitter {
 			});
 		}
 
-		const result: LinkResult = {
-			url: mapUrl(options.url.href, options.checkOptions),
-			status,
-			state,
-			parent: mapUrl(options.parent, options.checkOptions),
-			failureDetails: failures,
-		};
+		const result = withDisplayText(
+			{
+				url: mapUrl(options.url.href, options.checkOptions),
+				status,
+				state,
+				parent: mapUrl(options.parent, options.checkOptions),
+				failureDetails: failures,
+			},
+			options.displayText,
+		);
 		options.results.push(result);
 		this.emit('link', result);
+		options.fragmentCandidates.set(options.url.href, {
+			isHtml: response !== undefined && isHtml(response),
+			state,
+		});
 
 		// Check for fragment identifiers if needed (before we start crawling deeper)
 		// Only validate fragments if the base URL returned a successful (2xx) response
@@ -967,62 +1002,33 @@ export class LinkChecker extends EventEmitter {
 			isHtml(response) &&
 			state === LinkState.OK
 		) {
-			const fragmentsToValidate = this.fragmentsToCheck.get(options.url.href);
-			if (fragmentsToValidate && fragmentsToValidate.size > 0) {
-				// Convert and buffer the response body
-				const nodeStream = toNodeReadable(response.body);
-				const htmlContent = await bufferStream(nodeStream);
+			// Convert and buffer the response body
+			const nodeStream = toNodeReadable(response.body);
+			const htmlContent = await bufferStream(nodeStream);
 
-				// Check if this is likely a soft 404 by looking for noindex/nofollow meta tags
-				// Many soft 404 pages (pages that return 200 but show "Page Not Found") include these tags
-				const htmlString = htmlContent.toString('utf-8');
-				const isSoft404 =
-					htmlString.includes('content="noindex') &&
-					htmlString.includes('nofollow');
+			// Check if this is likely a soft 404 by looking for noindex/nofollow meta tags
+			// Many soft 404 pages (pages that return 200 but show "Page Not Found") include these tags
+			const htmlString = htmlContent.toString('utf-8');
+			const isSoft404 =
+				htmlString.includes('content="noindex') &&
+				htmlString.includes('nofollow');
 
-				// Only validate fragments if this is NOT a soft 404
-				if (!isSoft404) {
-					// Validate fragments
-					const validationResults = await validateFragments(
-						htmlContent,
-						fragmentsToValidate,
-					);
+			await this.cacheFragmentPage(
+				options,
+				options.url.href,
+				htmlContent,
+				response.status,
+				!isSoft404,
+			);
 
-					// Emit results for invalid fragments
-					for (const result of validationResults) {
-						if (!result.isValid) {
-							const fragmentResult: LinkResult = {
-								url: mapUrl(
-									`${options.url.href}#${result.fragment}`,
-									options.checkOptions,
-								),
-								status: response.status,
-								state: LinkState.BROKEN,
-								parent: mapUrl(options.parent, options.checkOptions),
-								failureDetails: [
-									new Error(
-										`Fragment identifier '#${result.fragment}' not found on page`,
-									),
-								],
-							};
-							options.results.push(fragmentResult);
-							this.emit('link', fragmentResult);
-						}
-					}
-				}
-
-				// Create a new stream from the buffered content for link extraction
-				const { Readable } = await import('node:stream');
-				const linkStream = Readable.from([htmlContent]);
-				response.body = linkStream as never;
-			}
+			// Create a new stream from the buffered content for link extraction
+			response.body = Readable.from([htmlContent]) as never;
 		}
 
 		// If we need to go deeper, scan the next level of depth for links and crawl
 		if (options.crawl && shouldRecurse) {
 			this.emit('pagestart', options.url);
 			let urlResults: Awaited<ReturnType<typeof getLinks>> = [];
-			let htmlContentForFragments: Buffer | undefined;
 			if (response?.body) {
 				// Convert to Node.js Readable stream (handles both Web and Node.js streams)
 				const nodeStream = toNodeReadable(response.body);
@@ -1037,13 +1043,11 @@ export class LinkChecker extends EventEmitter {
 
 				// Parse HTML or CSS depending on content type
 				if (isHtml(response)) {
-					// If we're checking fragments, buffer the HTML content so we can validate
-					// same-page fragments after extracting links
+					// Fragment checking buffered the response earlier, so recreate a stream
+					// before extracting links.
 					if (options.checkOptions.checkFragments) {
-						htmlContentForFragments = await bufferStream(nodeStream);
-						// Create a new stream from the buffer for link extraction
-						const { Readable } = await import('node:stream');
-						const linkStream = Readable.from([htmlContentForFragments]);
+						const htmlContent = await bufferStream(nodeStream);
+						const linkStream = Readable.from([htmlContent]);
 						urlResults = await getLinks(
 							linkStream,
 							baseUrl,
@@ -1060,23 +1064,15 @@ export class LinkChecker extends EventEmitter {
 					urlResults = await getCssLinks(nodeStream, baseUrl);
 				}
 			}
+			const skippedUrlResults = new Set<(typeof urlResults)[number]>();
+			const skippedFragmentResults = new Set<(typeof urlResults)[number]>();
+			const preferredDisplayTextByUrl = new Map<string, string>();
+			const fallbackDisplayTextByUrl = new Map<string, string>();
+			const preferredDisplayTextByFragment = new Map<string, string>();
 			for (const result of urlResults) {
-				// If there was some sort of problem parsing the link while
-				// creating a new URL obj, treat it as a broken link.
 				if (!result.url) {
-					const r = {
-						url: mapUrl(result.link, options.checkOptions),
-						status: 0,
-						state: LinkState.BROKEN,
-						parent: mapUrl(options.url.href, options.checkOptions),
-					};
-					options.results.push(r);
-					this.emit('link', r);
 					continue;
 				}
-
-				// Requests are deduplicated by the fragmentless URL, but skip rules
-				// should see the complete URL as it appeared in the document.
 				if (
 					this.hasSkipRules(options.checkOptions) &&
 					(result.url.protocol === 'http:' ||
@@ -1087,11 +1083,91 @@ export class LinkChecker extends EventEmitter {
 						options.checkOptions,
 					))
 				) {
-					const skippedResult: LinkResult = {
-						url: mapUrl(result.urlWithFragment, options.checkOptions),
-						state: LinkState.SKIPPED,
-						parent: mapUrl(options.url.href, options.checkOptions),
-					};
+					skippedUrlResults.add(result);
+					continue;
+				}
+				if (result.displayText !== undefined) {
+					const fallback = fallbackDisplayTextByUrl.get(result.url.href);
+					if (
+						fallback === undefined ||
+						(fallback === '' && result.displayText !== '')
+					) {
+						fallbackDisplayTextByUrl.set(result.url.href, result.displayText);
+					}
+				}
+				if (
+					options.checkOptions.checkFragments &&
+					result.fragment &&
+					result.urlWithFragment &&
+					(await this.shouldSkipFragment(
+						result.fragment,
+						result.urlWithFragment,
+						options.checkOptions,
+					))
+				) {
+					skippedFragmentResults.add(result);
+					continue;
+				}
+				if (result.displayText === undefined) {
+					continue;
+				}
+				const current = preferredDisplayTextByUrl.get(result.url.href);
+				if (
+					current === undefined ||
+					(current === '' && result.displayText !== '')
+				) {
+					preferredDisplayTextByUrl.set(result.url.href, result.displayText);
+				}
+				if (result.urlWithFragment && result.fragment) {
+					const fragmentUrl = this.rewriteUrl(
+						result.url.href,
+						options.checkOptions,
+					);
+					const fragmentKey = `${fragmentUrl}#${result.fragment}`;
+					const fragmentText = preferredDisplayTextByFragment.get(fragmentKey);
+					if (
+						fragmentText === undefined ||
+						(fragmentText === '' && result.displayText !== '')
+					) {
+						preferredDisplayTextByFragment.set(fragmentKey, result.displayText);
+					}
+				}
+			}
+			for (const result of urlResults) {
+				// If there was some sort of problem parsing the link while
+				// creating a new URL obj, treat it as a broken link.
+				if (!result.url) {
+					const r = withDisplayText(
+						{
+							url: mapUrl(result.link, options.checkOptions),
+							status: 0,
+							state: LinkState.BROKEN,
+							parent: mapUrl(options.url.href, options.checkOptions),
+						},
+						result.displayText,
+					);
+					options.results.push(r);
+					this.emit('link', r);
+					continue;
+				}
+				const preferredDisplayText =
+					preferredDisplayTextByUrl.get(result.url.href) ??
+					fallbackDisplayTextByUrl.get(result.url.href);
+
+				// Requests are deduplicated by the fragmentless URL, but skip rules
+				// should see the complete URL as it appeared in the document.
+				if (skippedUrlResults.has(result)) {
+					const skippedResult = withDisplayText(
+						{
+							url: mapUrl(
+								result.urlWithFragment as string,
+								options.checkOptions,
+							),
+							state: LinkState.SKIPPED,
+							parent: mapUrl(options.url.href, options.checkOptions),
+						},
+						result.displayText,
+					);
 					options.results.push(skippedResult);
 					this.emit('link', skippedResult);
 					continue;
@@ -1103,29 +1179,33 @@ export class LinkChecker extends EventEmitter {
 					result.fragment &&
 					result.fragment.length > 0
 				) {
-					if (
-						await this.shouldSkipFragment(
-							result.fragment,
-							result.urlWithFragment ?? result.url.href,
-							options.checkOptions,
-						)
-					) {
-						const skippedFragmentResult: LinkResult = {
-							url: mapUrl(
-								result.urlWithFragment ?? result.url.href,
-								options.checkOptions,
-							),
-							state: LinkState.SKIPPED,
-							parent: mapUrl(options.url.href, options.checkOptions),
-						};
+					if (skippedFragmentResults.has(result)) {
+						const skippedFragmentResult = withDisplayText(
+							{
+								url: mapUrl(
+									result.urlWithFragment as string,
+									options.checkOptions,
+								),
+								state: LinkState.SKIPPED,
+								parent: mapUrl(options.url.href, options.checkOptions),
+							},
+							result.displayText,
+						);
 						options.results.push(skippedFragmentResult);
 						this.emit('link', skippedFragmentResult);
 					} else {
-						const urlKey = result.url.href;
-						if (!this.fragmentsToCheck.has(urlKey)) {
-							this.fragmentsToCheck.set(urlKey, new Set());
-						}
-						this.fragmentsToCheck.get(urlKey)?.add(result.fragment);
+						const fragmentUrl = this.rewriteUrl(
+							result.url.href,
+							options.checkOptions,
+						);
+						this.registerFragmentReference(
+							options,
+							fragmentUrl,
+							result.fragment,
+							preferredDisplayTextByFragment.get(
+								`${fragmentUrl}#${result.fragment}`,
+							),
+						);
 					}
 				}
 
@@ -1167,9 +1247,14 @@ export class LinkChecker extends EventEmitter {
 					}
 					this.enqueueCrawl({
 						url: result.url,
+						displayText: preferredDisplayText,
 						crawl: crawl ?? false,
 						cache: options.cache,
 						relationshipCache: options.relationshipCache,
+						fragmentReferences: options.fragmentReferences,
+						fragmentRelationshipCache: options.fragmentRelationshipCache,
+						fragmentPages: options.fragmentPages,
+						fragmentCandidates: options.fragmentCandidates,
 						pendingChecks: options.pendingChecks,
 						delayCache: options.delayCache,
 						retryErrorsCache: options.retryErrorsCache,
@@ -1206,64 +1291,22 @@ export class LinkChecker extends EventEmitter {
 						const cachedResult = options.results.find(
 							(r) => r.url === mapUrl(urlHref, options.checkOptions),
 						);
-
 						// Only emit duplicate results for BROKEN links
 						if (cachedResult && cachedResult.state === LinkState.BROKEN) {
-							const reusedResult: LinkResult = {
-								url: cachedResult.url,
-								status: cachedResult.status,
-								state: cachedResult.state,
-								parent: mapUrl(parentHref, options.checkOptions),
-								failureDetails: cachedResult.failureDetails,
-							};
+							const reusedResult = withDisplayText(
+								{
+									url: cachedResult.url,
+									status: cachedResult.status,
+									state: cachedResult.state,
+									parent: mapUrl(parentHref, options.checkOptions),
+									failureDetails: cachedResult.failureDetails,
+								},
+								preferredDisplayText,
+							);
 							options.results.push(reusedResult);
 							this.emit('link', reusedResult);
 						}
 					});
-				}
-			}
-
-			// Validate same-page fragments that were found during link extraction
-			// These fragments reference the current page and need immediate validation
-			// since the page won't be checked again (it's already in the cache)
-			if (
-				options.checkOptions.checkFragments &&
-				htmlContentForFragments &&
-				response &&
-				isHtml(response) &&
-				state === LinkState.OK
-			) {
-				const samePageFragments = this.fragmentsToCheck.get(options.url.href);
-				if (samePageFragments && samePageFragments.size > 0) {
-					const validationResults = await validateFragments(
-						htmlContentForFragments,
-						samePageFragments,
-					);
-
-					// Emit results for invalid same-page fragments
-					for (const result of validationResults) {
-						if (!result.isValid) {
-							const fragmentResult: LinkResult = {
-								url: mapUrl(
-									`${options.url.href}#${result.fragment}`,
-									options.checkOptions,
-								),
-								status: response.status,
-								state: LinkState.BROKEN,
-								parent: mapUrl(options.parent, options.checkOptions),
-								failureDetails: [
-									new Error(
-										`Fragment identifier '#${result.fragment}' not found on page`,
-									),
-								],
-							};
-							options.results.push(fragmentResult);
-							this.emit('link', fragmentResult);
-						}
-					}
-
-					// Clear the validated fragments to avoid duplicate validation
-					this.fragmentsToCheck.delete(options.url.href);
 				}
 			}
 		}
@@ -1272,6 +1315,162 @@ export class LinkChecker extends EventEmitter {
 		// This is critical for preventing port exhaustion - if the body isn't consumed,
 		// the underlying TCP connection may not be reused.
 		await drainStream(response?.body);
+	}
+
+	private enqueueRemainingFragmentChecks(
+		context: FragmentContext,
+		fragmentCandidates: Map<string, FragmentCandidate>,
+		queue: Queue,
+	): void {
+		const redirectMode =
+			context.checkOptions.redirects === 'error' ? 'manual' : 'follow';
+		const processRedirectTarget =
+			redirectMode === 'follow' &&
+			(this.hasSkipRules(context.checkOptions) ||
+				Boolean(context.checkOptions.urlRewriteExpressions?.length))
+				? (url: string) => this.processRedirectTarget(url, context.checkOptions)
+				: undefined;
+		const requestOptions = {
+			headers: context.checkOptions.headers,
+			timeout: context.checkOptions.timeout,
+			redirect: redirectMode,
+			allowInsecureCerts: context.checkOptions.allowInsecureCerts,
+			processRedirectTarget,
+		} as const;
+
+		for (const url of context.fragmentReferences.keys()) {
+			const candidate = fragmentCandidates.get(url);
+			if (!candidate || candidate.state !== LinkState.OK || !candidate.isHtml) {
+				continue;
+			}
+
+			queue.add(async () => {
+				let response: RequestResponse | undefined;
+				try {
+					response = await makeRequest('GET', url, requestOptions);
+					if (
+						response.redirectSkipped ||
+						response.status < 200 ||
+						response.status >= 300 ||
+						!response.body ||
+						!isHtml(response)
+					) {
+						context.fragmentReferences.delete(url);
+						return;
+					}
+
+					const htmlContent = await bufferStream(toNodeReadable(response.body));
+					const htmlString = htmlContent.toString('utf-8');
+					const isSoft404 =
+						htmlString.includes('content="noindex') &&
+						htmlString.includes('nofollow');
+					await this.cacheFragmentPage(
+						context,
+						url,
+						htmlContent,
+						response.status,
+						!isSoft404,
+					);
+				} catch {
+					context.fragmentReferences.delete(url);
+				} finally {
+					await drainStream(response?.body);
+				}
+			});
+		}
+	}
+
+	private async cacheFragmentPage(
+		context: FragmentContext,
+		url: string,
+		htmlContent: Buffer,
+		status: number,
+		shouldValidate: boolean,
+	): Promise<void> {
+		const validFragments = shouldValidate
+			? await extractFragmentIds(Readable.from([htmlContent]))
+			: undefined;
+		context.fragmentPages.set(url, { status, validFragments });
+		const fragmentsToValidate = context.fragmentReferences.get(url);
+		context.fragmentReferences.delete(url);
+		if (!validFragments || !fragmentsToValidate) {
+			return;
+		}
+
+		for (const [fragment, references] of fragmentsToValidate) {
+			if (!validFragments.has(fragment)) {
+				for (const reference of references.values()) {
+					this.recordBrokenFragment(context, url, fragment, status, reference);
+				}
+			}
+		}
+	}
+
+	private recordBrokenFragment(
+		context: FragmentContext,
+		url: string,
+		fragment: string,
+		status: number,
+		reference: FragmentReference,
+	): void {
+		const fragmentResult = withDisplayText(
+			{
+				url: mapUrl(`${url}#${fragment}`, context.checkOptions),
+				status,
+				state: LinkState.BROKEN,
+				parent: mapUrl(reference.parent, context.checkOptions),
+				failureDetails: [
+					new Error(`Fragment identifier '#${fragment}' not found on page`),
+				],
+			},
+			reference.displayText,
+		);
+		context.results.push(fragmentResult);
+		this.emit('link', fragmentResult);
+	}
+
+	private registerFragmentReference(
+		options: CrawlOptions,
+		url: string,
+		fragment: string,
+		displayText?: string,
+	): void {
+		const parent = options.url.href;
+		const relationshipKey = `${url}#${fragment}|${parent}`;
+		if (options.fragmentRelationshipCache.has(relationshipKey)) {
+			return;
+		}
+		options.fragmentRelationshipCache.add(relationshipKey);
+
+		const reference = { displayText, parent };
+		const fragmentPage = options.fragmentPages.get(url);
+		if (fragmentPage) {
+			if (
+				fragmentPage.validFragments &&
+				!fragmentPage.validFragments.has(fragment)
+			) {
+				this.recordBrokenFragment(
+					options,
+					url,
+					fragment,
+					fragmentPage.status,
+					reference,
+				);
+			}
+			return;
+		}
+
+		let fragmentsForUrl = options.fragmentReferences.get(url);
+		if (!fragmentsForUrl) {
+			fragmentsForUrl = new Map();
+			options.fragmentReferences.set(url, fragmentsForUrl);
+		}
+		let references = fragmentsForUrl.get(fragment);
+		if (!references) {
+			references = new Map();
+			fragmentsForUrl.set(fragment, references);
+		}
+		references.set(parent, reference);
 	}
 
 	private hasSkipRules(checkOptions: InternalCheckOptions): boolean {
@@ -1341,15 +1540,18 @@ export class LinkChecker extends EventEmitter {
 	}
 
 	private recordSkippedResult(options: CrawlOptions): void {
-		const result: LinkResult = {
-			url: mapUrl(options.url.href, options.checkOptions),
-			status:
-				options.url.protocol === 'http:' || options.url.protocol === 'https:'
-					? undefined
-					: 0,
-			state: LinkState.SKIPPED,
-			parent: mapUrl(options.parent, options.checkOptions),
-		};
+		const result = withDisplayText(
+			{
+				url: mapUrl(options.url.href, options.checkOptions),
+				status:
+					options.url.protocol === 'http:' || options.url.protocol === 'https:'
+						? undefined
+						: 0,
+				state: LinkState.SKIPPED,
+				parent: mapUrl(options.parent, options.checkOptions),
+			},
+			options.displayText,
+		);
 		options.results.push(result);
 		this.emit('link', result);
 	}

--- a/src/links.ts
+++ b/src/links.ts
@@ -450,6 +450,13 @@ export type FragmentValidationResult = {
 	isValid: boolean;
 };
 
+export function isValidFragment(
+	fragment: string,
+	validFragments: Set<string>,
+): boolean {
+	return /^[tT][oO][pP]$/.test(fragment) || validFragments.has(fragment);
+}
+
 /**
  * Validates fragment identifiers against HTML content.
  * @param htmlContent The HTML content as a Buffer
@@ -469,7 +476,7 @@ export async function validateFragments(
 	for (const fragment of fragmentsToValidate) {
 		results.push({
 			fragment,
-			isValid: /^[tT][oO][pP]$/.test(fragment) || validFragments.has(fragment),
+			isValid: isValidFragment(fragment, validFragments),
 		});
 	}
 

--- a/src/links.ts
+++ b/src/links.ts
@@ -43,10 +43,16 @@ for (const attribute of Object.keys(linksAttribute)) {
 
 export type ParsedUrl = {
 	link: string;
+	displayText?: string;
 	error?: Error;
 	url?: URL;
 	urlWithFragment?: string;
 	fragment?: string;
+};
+
+type ActiveAnchor = {
+	link?: ParsedUrl;
+	text: string;
 };
 
 /**
@@ -84,9 +90,13 @@ export async function getLinks(
 	let styleTagContent = '';
 	let isJsonLd = false;
 	let jsonLdContent = '';
+	const activeAnchors: ActiveAnchor[] = [];
 
 	const parser = new WritableStream({
 		onopentag(tag: string, attributes: Record<string, string>) {
+			const activeAnchor: ActiveAnchor | undefined =
+				tag === 'a' ? { text: '' } : undefined;
+
 			// Allow alternate base URL to be specified in tag:
 			if (tag === 'base' && !baseSet) {
 				realBaseUrl = getBaseUrl(attributes.href, baseUrl);
@@ -149,13 +159,25 @@ export async function getLinks(
 					const linkString = attributes[attribute];
 					if (linkString) {
 						for (const link of parseAttribute(attribute, linkString)) {
-							links.push(parseLink(link, realBaseUrl));
+							const parsedLink = parseLink(link, realBaseUrl);
+							links.push(parsedLink);
+							if (activeAnchor && attribute === 'href') {
+								activeAnchor.link = parsedLink;
+							}
 						}
 					}
 				}
 			}
+
+			if (activeAnchor) {
+				activeAnchors.push(activeAnchor);
+			}
 		},
 		ontext(text: string) {
+			for (const activeAnchor of activeAnchors) {
+				activeAnchor.text += text;
+			}
+
 			// Collect text content when inside a <style> tag
 			if (isInStyleTag) {
 				styleTagContent += text;
@@ -166,6 +188,15 @@ export async function getLinks(
 			}
 		},
 		onclosetag(tag: string) {
+			if (tag === 'a') {
+				const activeAnchor = activeAnchors.pop();
+				if (activeAnchor?.link) {
+					activeAnchor.link.displayText = activeAnchor.text
+						.replace(/\s+/g, ' ')
+						.trim();
+				}
+			}
+
 			// When we close a <style> tag, extract URLs from the collected CSS
 			if (tag === 'style' && isInStyleTag) {
 				isInStyleTag = false;

--- a/test/fixtures/display-text-e2e/index.html
+++ b/test/fixtures/display-text-e2e/index.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+	<link rel="canonical" href="target.html">
+	<link rel="alternate" href="non-anchor.html">
+</head>
+<body>
+	<a href="target.html">Target page</a>
+	<a href="nested.html">Read <strong>nested documentation</strong></a>
+</body>
+</html>

--- a/test/fixtures/display-text-e2e/nested.html
+++ b/test/fixtures/display-text-e2e/nested.html
@@ -1,0 +1,1 @@
+<html><body>Nested</body></html>

--- a/test/fixtures/display-text-e2e/non-anchor.html
+++ b/test/fixtures/display-text-e2e/non-anchor.html
@@ -1,0 +1,1 @@
+<html><body>Non-anchor</body></html>

--- a/test/fixtures/display-text-e2e/target.html
+++ b/test/fixtures/display-text-e2e/target.html
@@ -1,0 +1,1 @@
+<html><body>Target</body></html>

--- a/test/fixtures/display-text-skip/index.html
+++ b/test/fixtures/display-text-skip/index.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+	<a href="http://example.invalid/target#skip">Skipped label</a>
+	<a href="http://example.invalid/target">Checked label</a>
+</body>
+</html>

--- a/test/fixtures/display-text/index.html
+++ b/test/fixtures/display-text/index.html
@@ -1,0 +1,16 @@
+<html>
+<head>
+	<link rel="canonical" href="http://example.invalid/plain">
+	<link rel="canonical" href="http://example.invalid/non-anchor">
+</head>
+<body>
+	<a href="http://example.invalid/plain">More information...</a>
+	<a href="http://example.invalid/nested">
+		Read <strong>the <em>documentation</em></strong> &amp; examples
+	</a>
+	<a href="http://example.invalid/empty"><span></span></a>
+	<a href="http://example.invalid/preferred"><span></span></a>
+	<a href="http://example.invalid/preferred">Preferred label</a>
+	<a>Anchor without an href</a>
+</body>
+</html>

--- a/test/fixtures/repeated-broken-link/pageA.html
+++ b/test/fixtures/repeated-broken-link/pageA.html
@@ -1,7 +1,7 @@
 <html>
 <body>
 <h1>Page A</h1>
-<a href="http://example.invalid/broken123">Broken Link 123</a>
+<a href="http://example.invalid/broken123">Broken Link 123 from A</a>
 <a href="http://example.invalid/broken456">Broken Link 456</a>
 </body>
 </html>

--- a/test/fixtures/repeated-broken-link/pageB.html
+++ b/test/fixtures/repeated-broken-link/pageB.html
@@ -1,7 +1,7 @@
 <html>
 <body>
 <h1>Page B</h1>
-<a href="http://example.invalid/broken123">Broken Link 123</a>
+<a href="http://example.invalid/broken123">Broken Link 123 from B</a>
 <a href="http://example.invalid/broken789">Broken Link 789</a>
 </body>
 </html>

--- a/test/test.cli.ts
+++ b/test/test.cli.ts
@@ -235,6 +235,44 @@ describe('cli', () => {
 		assert.ok(output.links);
 	});
 
+	it('should serialize display text through the built CLI', async () => {
+		const response = await execa(node, [
+			linkinator,
+			'--format',
+			'json',
+			'test/fixtures/display-text-e2e',
+		]);
+		const output = JSON.parse(response.stdout) as { links: LinkResult[] };
+		const findResult = (suffix: string) =>
+			output.links.find((link) => link.url.endsWith(suffix));
+
+		assert.strictEqual(findResult('target.html')?.displayText, 'Target page');
+		assert.strictEqual(
+			findResult('nested.html')?.displayText,
+			'Read nested documentation',
+		);
+		assert.ok(
+			!Object.hasOwn(findResult('non-anchor.html') ?? {}, 'displayText'),
+		);
+		assert.ok(
+			!Object.hasOwn(
+				output.links.find((link) => !link.parent) ?? {},
+				'displayText',
+			),
+		);
+
+		const csvResponse = await execa(node, [
+			linkinator,
+			'--format',
+			'csv',
+			'test/fixtures/display-text-e2e',
+		]);
+		assert.strictEqual(
+			csvResponse.stdout.split('\n')[0],
+			'url,status,state,parent,failureDetails',
+		);
+	});
+
 	it('should look for linkinator.config.json in the cwd', async () => {
 		const response = await execa(node, ['../../../build/src/cli.js', '.'], {
 			cwd: 'test/fixtures/defaultconfig',

--- a/test/test.fragments.ts
+++ b/test/test.fragments.ts
@@ -146,6 +146,224 @@ describe('fragment identifier validation', () => {
 		);
 	});
 
+	it('should retry transient fragment metadata server errors', async () => {
+		const mockPool = mockAgent.get('http://example.com');
+		mockPool
+			.intercept({ path: '/page.html', method: 'HEAD' })
+			.reply(200, '', { headers: { 'content-type': 'text/html' } });
+		mockPool
+			.intercept({ path: '/page.html', method: 'GET' })
+			.reply(500, 'retry', { headers: { 'content-type': 'text/html' } });
+		mockPool
+			.intercept({ path: '/page.html', method: 'GET' })
+			.reply(200, '<div id="different-section">Content</div>', {
+				headers: { 'content-type': 'text/html' },
+			});
+		const checker = new LinkChecker();
+		const retries: Array<{ status: number; url: string }> = [];
+		checker.on('retry', (event) => retries.push(event));
+
+		const results = await checker.check({
+			path: 'test/fixtures/fragments-invalid',
+			checkFragments: true,
+			retryErrors: true,
+			retryErrorsCount: 1,
+			retryErrorsJitter: 0,
+		});
+
+		expect(results.passed).toBe(false);
+		expect(retries).toEqual([
+			expect.objectContaining({
+				status: 500,
+				url: 'http://example.com/page.html',
+			}),
+		]);
+		expect(
+			results.links.find((result) => result.url.endsWith('#invalid-section'))
+				?.state,
+		).toBe(LinkState.BROKEN);
+	});
+
+	it('should keep exhausted fragment metadata network retries supplementary', async () => {
+		const mockPool = mockAgent.get('http://example.com');
+		mockPool
+			.intercept({ path: '/page.html', method: 'HEAD' })
+			.reply(200, '', { headers: { 'content-type': 'text/html' } });
+		mockPool
+			.intercept({ path: '/page.html', method: 'GET' })
+			.replyWithError(new Error('temporary metadata failure'));
+		mockPool
+			.intercept({ path: '/page.html', method: 'GET' })
+			.replyWithError(new Error('metadata still unavailable'));
+		const checker = new LinkChecker();
+		const retries: Array<{ status: number; url: string }> = [];
+		checker.on('retry', (event) => retries.push(event));
+
+		const results = await checker.check({
+			path: 'test/fixtures/fragments-invalid',
+			checkFragments: true,
+			retryErrors: true,
+			retryErrorsCount: 1,
+			retryErrorsJitter: 0,
+		});
+
+		expect(results.passed).toBe(true);
+		expect(retries).toEqual([
+			expect.objectContaining({
+				status: 0,
+				url: 'http://example.com/page.html',
+			}),
+		]);
+		expect(
+			results.links.some((result) => result.url.endsWith('#invalid-section')),
+		).toBe(false);
+	});
+
+	it('should honor Retry-After for fragment metadata requests', async () => {
+		const mockPool = mockAgent.get('http://example.com');
+		mockPool
+			.intercept({ path: '/page.html', method: 'HEAD' })
+			.reply(200, '', { headers: { 'content-type': 'text/html' } });
+		mockPool
+			.intercept({ path: '/page.html', method: 'GET' })
+			.reply(429, 'retry', {
+				headers: {
+					'content-type': 'text/html',
+					'retry-after': '0',
+				},
+			});
+		mockPool
+			.intercept({ path: '/page.html', method: 'GET' })
+			.reply(200, '<div id="different-section">Content</div>', {
+				headers: { 'content-type': 'text/html' },
+			});
+		const checker = new LinkChecker();
+		const retries: Array<{ status: number; url: string }> = [];
+		checker.on('retry', (event) => retries.push(event));
+
+		const results = await checker.check({
+			path: 'test/fixtures/fragments-invalid',
+			checkFragments: true,
+			retry: true,
+		});
+
+		expect(results.passed).toBe(false);
+		expect(retries).toEqual([
+			expect.objectContaining({
+				status: 429,
+				url: 'http://example.com/page.html',
+			}),
+		]);
+		expect(
+			results.links.find((result) => result.url.endsWith('#invalid-section'))
+				?.state,
+		).toBe(LinkState.BROKEN);
+	});
+
+	it('should check other fragment targets during Retry-After backoff', async () => {
+		const mockPool = mockAgent.get('http://example.com');
+		mockPool
+			.intercept({ path: '/source.html', method: 'GET' })
+			.reply(
+				200,
+				[
+					'<a href="/slow.html#missing">Slow</a>',
+					'<a href="/fast.html#missing">Fast</a>',
+				].join(''),
+				{ headers: { 'content-type': 'text/html' } },
+			);
+		for (const path of ['/slow.html', '/fast.html']) {
+			mockPool
+				.intercept({ path, method: 'HEAD' })
+				.reply(200, '', { headers: { 'content-type': 'text/html' } });
+		}
+		const requestOrder: string[] = [];
+		mockPool.intercept({ path: '/slow.html', method: 'GET' }).reply(() => {
+			requestOrder.push('slow-429');
+			return {
+				statusCode: 429,
+				data: 'retry',
+				responseOptions: {
+					headers: {
+						'content-type': 'text/html',
+						'retry-after': '0.1',
+					},
+				},
+			};
+		});
+		mockPool.intercept({ path: '/slow.html', method: 'GET' }).reply(() => {
+			requestOrder.push('slow-retry');
+			return {
+				statusCode: 200,
+				data: '<div id="different">Slow target</div>',
+				responseOptions: { headers: { 'content-type': 'text/html' } },
+			};
+		});
+		mockPool.intercept({ path: '/fast.html', method: 'GET' }).reply(() => {
+			requestOrder.push('fast');
+			return {
+				statusCode: 200,
+				data: '<div id="different">Fast target</div>',
+				responseOptions: { headers: { 'content-type': 'text/html' } },
+			};
+		});
+		const checker = new LinkChecker();
+
+		const results = await checker.check({
+			path: 'http://example.com/source.html',
+			checkFragments: true,
+			concurrency: 1,
+			retry: true,
+		});
+
+		expect(results.passed).toBe(false);
+		expect(requestOrder).toEqual(['slow-429', 'fast', 'slow-retry']);
+	});
+
+	it('should apply error retries when fragment Retry-After is invalid', async () => {
+		const mockPool = mockAgent.get('http://example.com');
+		mockPool
+			.intercept({ path: '/page.html', method: 'HEAD' })
+			.reply(200, '', { headers: { 'content-type': 'text/html' } });
+		mockPool
+			.intercept({ path: '/page.html', method: 'GET' })
+			.reply(429, 'retry', {
+				headers: {
+					'content-type': 'text/html',
+					'retry-after': 'not-a-date',
+				},
+			});
+		mockPool
+			.intercept({ path: '/page.html', method: 'GET' })
+			.reply(200, '<div id="different-section">Content</div>', {
+				headers: { 'content-type': 'text/html' },
+			});
+		const checker = new LinkChecker();
+		const retries: Array<{ status: number; url: string }> = [];
+		checker.on('retry', (event) => retries.push(event));
+
+		const results = await checker.check({
+			path: 'test/fixtures/fragments-invalid',
+			checkFragments: true,
+			retry: true,
+			retryErrors: true,
+			retryErrorsCount: 1,
+			retryErrorsJitter: 0,
+		});
+
+		expect(results.passed).toBe(false);
+		expect(retries).toEqual([
+			expect.objectContaining({
+				status: 429,
+				url: 'http://example.com/page.html',
+			}),
+		]);
+		expect(
+			results.links.find((result) => result.url.endsWith('#invalid-section'))
+				?.state,
+		).toBe(LinkState.BROKEN);
+	});
+
 	it('should report an invalid fragment for every parent page', async () => {
 		const mockPool = mockAgent.get('http://example.com');
 		mockPool

--- a/test/test.fragments.ts
+++ b/test/test.fragments.ts
@@ -146,6 +146,540 @@ describe('fragment identifier validation', () => {
 		);
 	});
 
+	it('should report an invalid fragment for every parent page', async () => {
+		const mockPool = mockAgent.get('http://example.com');
+		mockPool
+			.intercept({ path: '/first.html', method: 'GET' })
+			.reply(
+				200,
+				'<a href="/target.html#missing"><span></span></a><a href="/target.html#missing">First label</a>',
+				{ headers: { 'content-type': 'text/html' } },
+			);
+		mockPool
+			.intercept({ path: '/second.html', method: 'GET' })
+			.reply(200, '<a href="/target.html#late-missing">Second label</a>', {
+				headers: { 'content-type': 'text/html' },
+			})
+			.delay(100);
+		mockPool
+			.intercept({ path: '/target.html', method: 'HEAD' })
+			.reply(200, '', { headers: { 'content-type': 'text/html' } });
+		mockPool
+			.intercept({ path: '/target.html', method: 'GET' })
+			.reply(
+				200,
+				'<div id="different">Content</div><a href="#different">Valid self link</a>',
+				{
+					headers: { 'content-type': 'text/html' },
+				},
+			);
+
+		const results = await check({
+			path: ['http://example.com/first.html', 'http://example.com/second.html'],
+			checkFragments: true,
+		});
+
+		const fragmentResults = results.links.filter((result) =>
+			result.url.includes('/target.html#'),
+		);
+		expect(fragmentResults).toHaveLength(2);
+		expect(
+			fragmentResults.map(({ displayText, parent, url }) => ({
+				displayText,
+				parent,
+				url,
+			})),
+		).toEqual([
+			{
+				displayText: 'First label',
+				parent: 'http://example.com/first.html',
+				url: 'http://example.com/target.html#missing',
+			},
+			{
+				displayText: 'Second label',
+				parent: 'http://example.com/second.html',
+				url: 'http://example.com/target.html#late-missing',
+			},
+		]);
+	});
+
+	it('should validate a fragment discovered after a non-fragment link', async () => {
+		const mockPool = mockAgent.get('http://example.com');
+		mockPool
+			.intercept({ path: '/first.html', method: 'GET' })
+			.reply(200, '<link rel="canonical" href="/target.html">', {
+				headers: { 'content-type': 'text/html' },
+			});
+		mockPool
+			.intercept({ path: '/second.html', method: 'GET' })
+			.reply(200, '<a href="/target.html#late-missing">Late label</a>', {
+				headers: { 'content-type': 'text/html' },
+			})
+			.delay(100);
+		mockPool
+			.intercept({ path: '/target.html', method: 'HEAD' })
+			.reply(200, '', { headers: { 'content-type': 'text/html' } });
+		mockPool.intercept({ path: '/target.html', method: 'GET' }).reply(302, '', {
+			headers: {
+				'content-type': 'text/html',
+				location: '/final.html',
+			},
+		});
+		mockPool
+			.intercept({ path: '/final.html', method: 'GET' })
+			.reply(200, '<div id="different">Content</div>', {
+				headers: { 'content-type': 'text/html' },
+			});
+
+		const results = await check({
+			path: ['http://example.com/first.html', 'http://example.com/second.html'],
+			checkFragments: true,
+			linksToSkip: ['/never-skip$'],
+		});
+
+		const fragmentResult = results.links.find((result) =>
+			result.url.endsWith('/target.html#late-missing'),
+		);
+		expect(fragmentResult?.state).toBe(LinkState.BROKEN);
+		expect(fragmentResult?.displayText).toBe('Late label');
+		expect(fragmentResult?.parent).toBe('http://example.com/second.html');
+	});
+
+	it('should tolerate unusable late fragment metadata responses', async () => {
+		const mockPool = mockAgent.get('http://example.com');
+		mockPool
+			.intercept({ path: '/first.html', method: 'GET' })
+			.reply(
+				200,
+				[
+					'<link rel="canonical" href="/not-found.html">',
+					'<link rel="canonical" href="/error.html">',
+					'<link rel="canonical" href="/soft.html">',
+				].join(''),
+				{ headers: { 'content-type': 'text/html' } },
+			);
+		mockPool
+			.intercept({ path: '/second.html', method: 'GET' })
+			.reply(
+				200,
+				[
+					'<a href="/not-found.html#missing">Not found</a>',
+					'<a href="/error.html#missing">Error</a>',
+					'<a href="/soft.html#missing">Soft 404</a>',
+				].join(''),
+				{ headers: { 'content-type': 'text/html' } },
+			)
+			.delay(100);
+		for (const path of ['/not-found.html', '/error.html', '/soft.html']) {
+			mockPool
+				.intercept({ path, method: 'HEAD' })
+				.reply(200, '', { headers: { 'content-type': 'text/html' } });
+		}
+		mockPool
+			.intercept({ path: '/not-found.html', method: 'GET' })
+			.reply(404, 'Not found', { headers: { 'content-type': 'text/html' } });
+		mockPool
+			.intercept({ path: '/error.html', method: 'GET' })
+			.replyWithError(new Error('metadata fetch failed'));
+		mockPool
+			.intercept({ path: '/soft.html', method: 'GET' })
+			.reply(
+				200,
+				'<meta name="robots" content="noindex,nofollow"><p>Not found</p>',
+				{ headers: { 'content-type': 'text/html' } },
+			);
+
+		const results = await check({
+			path: ['http://example.com/first.html', 'http://example.com/second.html'],
+			checkFragments: true,
+		});
+
+		expect(results.passed).toBe(true);
+		expect(results.links.some((result) => result.url.includes('#'))).toBe(
+			false,
+		);
+	});
+
+	it('should ignore fragment metadata that redirects to a skipped URL', async () => {
+		const mockPool = mockAgent.get('http://example.com');
+		mockPool
+			.intercept({ path: '/source.html', method: 'GET' })
+			.reply(200, '<a href="/target.html#missing">Target label</a>', {
+				headers: { 'content-type': 'text/html' },
+			});
+		mockPool
+			.intercept({ path: '/target.html', method: 'HEAD' })
+			.reply(200, '', { headers: { 'content-type': 'text/html' } });
+		mockPool.intercept({ path: '/target.html', method: 'GET' }).reply(302, '', {
+			headers: {
+				'content-type': 'text/html',
+				location: '/skip-me',
+			},
+		});
+
+		const results = await check({
+			path: 'http://example.com/source.html',
+			checkFragments: true,
+			linksToSkip: ['/skip-me$'],
+		});
+
+		const target = results.links.find(
+			(result) => result.url === 'http://example.com/target.html',
+		);
+		expect(target?.state).toBe(LinkState.OK);
+		expect(target?.displayText).toBe('Target label');
+		expect(
+			results.links.some((result) => result.url.endsWith('#missing')),
+		).toBe(false);
+	});
+
+	it('should keep an early fragment metadata failure supplementary', async () => {
+		const mockPool = mockAgent.get('http://example.com');
+		mockPool
+			.intercept({ path: '/source.html', method: 'GET' })
+			.reply(200, '<a href="/target.html#missing">Target label</a>', {
+				headers: { 'content-type': 'text/html' },
+			});
+		mockPool
+			.intercept({ path: '/target.html', method: 'HEAD' })
+			.reply(200, '', { headers: { 'content-type': 'text/html' } });
+		mockPool
+			.intercept({ path: '/target.html', method: 'GET' })
+			.reply(404, 'Not found', { headers: { 'content-type': 'text/html' } });
+
+		const results = await check({
+			path: 'http://example.com/source.html',
+			checkFragments: true,
+		});
+
+		const target = results.links.find(
+			(result) => result.url === 'http://example.com/target.html',
+		);
+		expect(results.passed).toBe(true);
+		expect(target?.status).toBe(200);
+		expect(target?.state).toBe(LinkState.OK);
+		expect(
+			results.links.some((result) => result.url.endsWith('#missing')),
+		).toBe(false);
+	});
+
+	it('should validate a fragment whose target URL is rewritten', async () => {
+		const mockPool = mockAgent.get('http://example.com');
+		mockPool
+			.intercept({ path: '/source.html', method: 'GET' })
+			.reply(200, '<a href="/old.html#missing">Rewritten target</a>', {
+				headers: { 'content-type': 'text/html' },
+			});
+		mockPool
+			.intercept({ path: '/target.html', method: 'HEAD' })
+			.reply(200, '', { headers: { 'content-type': 'text/html' } });
+		mockPool
+			.intercept({ path: '/target.html', method: 'GET' })
+			.reply(200, '<div id="different">Content</div>', {
+				headers: { 'content-type': 'text/html' },
+			});
+
+		const results = await check({
+			path: 'http://example.com/source.html',
+			checkFragments: true,
+			urlRewriteExpressions: [
+				{ pattern: /\/old\.html$/, replacement: '/target.html' },
+			],
+		});
+
+		const fragmentResult = results.links.find((result) =>
+			result.url.endsWith('/target.html#missing'),
+		);
+		expect(fragmentResult?.state).toBe(LinkState.BROKEN);
+		expect(fragmentResult?.displayText).toBe('Rewritten target');
+	});
+
+	it('should validate a late fragment whose target URL is rewritten', async () => {
+		const mockPool = mockAgent.get('http://example.com');
+		mockPool
+			.intercept({ path: '/first.html', method: 'GET' })
+			.reply(200, '<link rel="canonical" href="/old.html">', {
+				headers: { 'content-type': 'text/html' },
+			});
+		mockPool
+			.intercept({ path: '/second.html', method: 'GET' })
+			.reply(200, '<a href="/old.html#late-missing">Late rewritten</a>', {
+				headers: { 'content-type': 'text/html' },
+			})
+			.delay(100);
+		mockPool
+			.intercept({ path: '/target.html', method: 'HEAD' })
+			.reply(200, '', { headers: { 'content-type': 'text/html' } });
+		mockPool
+			.intercept({ path: '/target.html', method: 'GET' })
+			.reply(200, '<div id="different">Content</div>', {
+				headers: { 'content-type': 'text/html' },
+			});
+
+		const results = await check({
+			path: ['http://example.com/first.html', 'http://example.com/second.html'],
+			checkFragments: true,
+			urlRewriteExpressions: [
+				{ pattern: /\/old\.html$/, replacement: '/target.html' },
+			],
+		});
+
+		const fragmentResult = results.links.find((result) =>
+			result.url.endsWith('/target.html#late-missing'),
+		);
+		expect(fragmentResult?.state).toBe(LinkState.BROKEN);
+		expect(fragmentResult?.displayText).toBe('Late rewritten');
+	});
+
+	it('should not validate fragments on a soft-404 page', async () => {
+		const mockPool = mockAgent.get('http://example.com');
+		mockPool
+			.intercept({ path: '/source.html', method: 'GET' })
+			.reply(200, '<a href="/target.html#missing">Target label</a>', {
+				headers: { 'content-type': 'text/html' },
+			});
+		mockPool
+			.intercept({ path: '/target.html', method: 'HEAD' })
+			.reply(200, '', { headers: { 'content-type': 'text/html' } });
+		mockPool
+			.intercept({ path: '/target.html', method: 'GET' })
+			.reply(
+				200,
+				'<meta name="robots" content="noindex,nofollow"><p>Not found</p>',
+				{ headers: { 'content-type': 'text/html' } },
+			);
+
+		const results = await check({
+			path: 'http://example.com/source.html',
+			checkFragments: true,
+		});
+
+		expect(results.passed).toBe(true);
+		expect(
+			results.links.some((result) => result.url.endsWith('#missing')),
+		).toBe(false);
+	});
+
+	it('should not validate same-page fragments on a crawled soft-404 page', async () => {
+		const mockPool = mockAgent.get('http://example.com');
+		mockPool
+			.intercept({ path: '/soft-root.html', method: 'GET' })
+			.reply(
+				200,
+				'<meta name="robots" content="noindex,nofollow"><a href="#missing">Missing</a>',
+				{ headers: { 'content-type': 'text/html' } },
+			);
+
+		const results = await check({
+			path: 'http://example.com/soft-root.html',
+			checkFragments: true,
+		});
+
+		expect(results.passed).toBe(true);
+		expect(results.links.some((result) => result.url.includes('#'))).toBe(
+			false,
+		);
+	});
+
+	it('should not report a recursively crawled fragment twice', async () => {
+		const mockPool = mockAgent.get('http://example.com');
+		mockPool
+			.intercept({ path: '/', method: 'GET' })
+			.reply(200, '<a href="/target.html#missing">Missing section</a>', {
+				headers: { 'content-type': 'text/html' },
+			});
+		mockPool
+			.intercept({ path: '/target.html', method: 'GET' })
+			.reply(200, '<div id="different">Content</div>', {
+				headers: { 'content-type': 'text/html' },
+			});
+
+		const checker = new LinkChecker();
+		const fragmentEvents: string[] = [];
+		checker.on('link', (result) => {
+			if (result.url.endsWith('/target.html#missing')) {
+				fragmentEvents.push(result.url);
+			}
+		});
+		const results = await checker.check({
+			path: 'http://example.com/',
+			checkFragments: true,
+			recurse: true,
+		});
+
+		expect(
+			results.links.filter((result) =>
+				result.url.endsWith('/target.html#missing'),
+			),
+		).toHaveLength(1);
+		expect(fragmentEvents).toHaveLength(1);
+	});
+
+	it('should reuse cached fragment validations for recursive self-links', async () => {
+		const mockPool = mockAgent.get('http://example.com');
+		mockPool
+			.intercept({ path: '/', method: 'GET' })
+			.reply(
+				200,
+				'<a href="/target.html#missing">Root missing</a><a href="/target.html#valid">Root valid</a>',
+				{ headers: { 'content-type': 'text/html' } },
+			);
+		mockPool
+			.intercept({ path: '/target.html', method: 'GET' })
+			.reply(
+				200,
+				[
+					'<div id="valid">Valid</div>',
+					'<a href="#missing"><span></span></a>',
+					'<a href="#missing">Self missing</a>',
+					'<a href="#valid">Valid once</a>',
+					'<a href="#valid">Valid twice</a>',
+					'<div id="new-valid">Also valid</div>',
+					'<a href="#new-valid">New valid</a>',
+				].join(''),
+				{ headers: { 'content-type': 'text/html' } },
+			);
+
+		const results = await check({
+			path: 'http://example.com/',
+			checkFragments: true,
+			recurse: true,
+		});
+
+		const brokenFragments = results.links.filter(
+			(result) =>
+				result.url === 'http://example.com/target.html#missing' &&
+				result.state === LinkState.BROKEN,
+		);
+		expect(brokenFragments).toHaveLength(2);
+		expect(
+			brokenFragments.map(({ displayText, parent }) => ({
+				displayText,
+				parent,
+			})),
+		).toEqual([
+			{ displayText: 'Root missing', parent: 'http://example.com/' },
+			{
+				displayText: 'Self missing',
+				parent: 'http://example.com/target.html',
+			},
+		]);
+		expect(
+			results.links.some(
+				(result) =>
+					result.url.endsWith('#valid') || result.url.endsWith('#new-valid'),
+			),
+		).toBe(false);
+	});
+
+	it('should retain fragment references registered before validation', async () => {
+		const mockPool = mockAgent.get('http://example.com');
+		for (const [path, label] of [
+			['/first.html', 'First label'],
+			['/second.html', 'Second label'],
+		] as const) {
+			mockPool
+				.intercept({ path, method: 'GET' })
+				.reply(200, `<a href="/target.html#missing">${label}</a>`, {
+					headers: { 'content-type': 'text/html' },
+				});
+		}
+		mockPool
+			.intercept({ path: '/target.html', method: 'HEAD' })
+			.reply(200, '', { headers: { 'content-type': 'text/html' } });
+		mockPool
+			.intercept({ path: '/target.html', method: 'GET' })
+			.reply(200, '<div id="different">Content</div>', {
+				headers: { 'content-type': 'text/html' },
+			});
+
+		const results = await check({
+			path: ['http://example.com/first.html', 'http://example.com/second.html'],
+			checkFragments: true,
+			concurrency: 1,
+		});
+
+		const fragmentResults = results.links.filter((result) =>
+			result.url.endsWith('/target.html#missing'),
+		);
+		expect(fragmentResults).toHaveLength(2);
+		expect(
+			fragmentResults.map(({ displayText }) => displayText).sort(),
+		).toEqual(['First label', 'Second label']);
+	});
+
+	it('should share preferred text across encoded-equivalent fragments', async () => {
+		const mockPool = mockAgent.get('http://example.com');
+		mockPool
+			.intercept({ path: '/source.html', method: 'GET' })
+			.reply(
+				200,
+				'<a href="/target.html#foo"><span></span></a><a href="/target.html#%66oo">Good label</a>',
+				{ headers: { 'content-type': 'text/html' } },
+			);
+		mockPool
+			.intercept({ path: '/target.html', method: 'HEAD' })
+			.reply(200, '', { headers: { 'content-type': 'text/html' } });
+		mockPool
+			.intercept({ path: '/target.html', method: 'GET' })
+			.reply(200, '<div id="different">Content</div>', {
+				headers: { 'content-type': 'text/html' },
+			});
+
+		const results = await check({
+			path: 'http://example.com/source.html',
+			checkFragments: true,
+		});
+
+		const fragmentResults = results.links.filter((result) =>
+			result.url.endsWith('/target.html#foo'),
+		);
+		expect(fragmentResults).toHaveLength(1);
+		expect(fragmentResults[0].displayText).toBe('Good label');
+	});
+
+	it('should isolate fragment metadata between LinkChecker checks', async () => {
+		const mockPool = mockAgent.get('http://example.com');
+		for (const [path, label] of [
+			['/first.html', 'First label'],
+			['/second.html', 'Second label'],
+		] as const) {
+			mockPool
+				.intercept({ path, method: 'GET' })
+				.reply(200, `<a href="/target.html#missing">${label}</a>`, {
+					headers: { 'content-type': 'text/html' },
+				});
+			mockPool
+				.intercept({ path: '/target.html', method: 'HEAD' })
+				.reply(200, '', { headers: { 'content-type': 'text/html' } });
+			mockPool
+				.intercept({ path: '/target.html', method: 'GET' })
+				.reply(200, '<div id="different">Content</div>', {
+					headers: { 'content-type': 'text/html' },
+				});
+		}
+
+		const checker = new LinkChecker();
+		const first = await checker.check({
+			path: 'http://example.com/first.html',
+			checkFragments: true,
+		});
+		const second = await checker.check({
+			path: 'http://example.com/second.html',
+			checkFragments: true,
+		});
+
+		expect(
+			first.links.find((result) => result.url.includes('#missing'))
+				?.displayText,
+		).toBe('First label');
+		const secondFragment = second.links.find((result) =>
+			result.url.includes('#missing'),
+		);
+		expect(secondFragment?.displayText).toBe('Second label');
+		expect(secondFragment?.parent).toBe('http://example.com/second.html');
+	});
+
 	it('should not check fragments when checkFragments is disabled', async () => {
 		const mockPool = mockAgent.get('http://example.com');
 
@@ -385,6 +919,9 @@ describe('fragment identifier validation', () => {
 			l.url.includes('#nonexistent-section'),
 		);
 		expect(brokenFragment?.state).toBe(LinkState.BROKEN);
+		expect(brokenFragment?.displayText).toBe(
+			'Link to nonexistent section (should fail)',
+		);
 		expect(brokenFragment?.failureDetails?.[0]).toBeInstanceOf(Error);
 		expect((brokenFragment?.failureDetails?.[0] as Error).message).toContain(
 			"Fragment identifier '#nonexistent-section' not found on page",
@@ -489,6 +1026,7 @@ describe('fragment identifier validation', () => {
 			l.url.includes('#nonexistent-section'),
 		);
 		expect(brokenFragment?.state).toBe(LinkState.BROKEN);
+		expect(brokenFragment?.displayText).toBe('Link to nonexistent section');
 		expect(brokenFragment?.failureDetails?.[0]).toBeInstanceOf(Error);
 		expect((brokenFragment?.failureDetails?.[0] as Error).message).toContain(
 			"Fragment identifier '#nonexistent-section' not found on page",

--- a/test/test.index.ts
+++ b/test/test.index.ts
@@ -15,6 +15,7 @@ import {
 	type CheckOptions,
 	check,
 	LinkChecker,
+	type LinkResult,
 	LinkState,
 } from '../src/index.js';
 import { DEFAULT_USER_AGENT } from '../src/options.js';
@@ -50,6 +51,191 @@ describe('linkinator', () => {
 		mockPool.intercept({ path: '/', method: 'HEAD' }).reply(200, '');
 		const results = await check({ path: 'test/fixtures/basic' });
 		assert.ok(results.passed);
+	});
+
+	it('should include normalized anchor display text in API results', async () => {
+		const mockPool = mockAgent.get('http://example.invalid');
+		for (const target of [
+			'non-anchor',
+			'plain',
+			'nested',
+			'empty',
+			'preferred',
+		]) {
+			mockPool.intercept({ path: `/${target}`, method: 'HEAD' }).reply(200, '');
+		}
+
+		const results = await check({ path: 'test/fixtures/display-text' });
+		assert.ok(results.passed);
+
+		const findResult = (path: string) =>
+			results.links.find((link) => link.url.endsWith(`/${path}`));
+		expect(findResult('plain')?.displayText).toBe('More information...');
+		expect(findResult('nested')?.displayText).toBe(
+			'Read the documentation & examples',
+		);
+		expect(findResult('empty')?.displayText).toBe('');
+		expect(findResult('preferred')?.displayText).toBe('Preferred label');
+		expect(findResult('non-anchor')?.displayText).toBeUndefined();
+		expect(Object.hasOwn(findResult('non-anchor') ?? {}, 'displayText')).toBe(
+			false,
+		);
+		const rootResult = results.links.find((link) => !link.parent);
+		expect(rootResult?.displayText).toBeUndefined();
+		expect(Object.hasOwn(rootResult ?? {}, 'displayText')).toBe(false);
+	});
+
+	it('should not take display text from a skipped occurrence', async () => {
+		const mockPool = mockAgent.get('http://example.invalid');
+		mockPool.intercept({ path: '/target', method: 'HEAD' }).reply(200, '');
+
+		const results = await check({
+			path: 'test/fixtures/display-text-skip',
+			linksToSkip: ['#skip$'],
+		});
+		const checked = results.links.find(
+			(result) =>
+				result.url === 'http://example.invalid/target' &&
+				result.state === LinkState.OK,
+		);
+		expect(checked?.displayText).toBe('Checked label');
+	});
+
+	it('should not take display text from a fragment-skipped occurrence', async () => {
+		const mockPool = mockAgent.get('http://example.invalid');
+		mockPool.intercept({ path: '/target', method: 'HEAD' }).reply(200, '');
+
+		const results = await check({
+			path: 'test/fixtures/display-text-skip',
+			checkFragments: true,
+			fragmentsToSkip: ['^skip$'],
+		});
+		const checked = results.links.find(
+			(result) =>
+				result.url === 'http://example.invalid/target' &&
+				result.state === LinkState.OK,
+		);
+		expect(checked?.displayText).toBe('Checked label');
+	});
+
+	it('should use a fragment-skipped label when it is the only occurrence', async () => {
+		const mockPool = mockAgent.get('http://example.invalid');
+		mockPool
+			.intercept({ path: '/source.html', method: 'GET' })
+			.reply(200, '<a href="/target#skip">Only label</a>', {
+				headers: { 'content-type': 'text/html' },
+			});
+		mockPool
+			.intercept({ path: '/target', method: 'HEAD' })
+			.reply(200, '', { headers: { 'content-type': 'text/html' } });
+
+		const results = await check({
+			path: 'http://example.invalid/source.html',
+			checkFragments: true,
+			fragmentsToSkip: ['^skip$'],
+		});
+		const target = results.links.find(
+			(result) =>
+				result.url === 'http://example.invalid/target' &&
+				result.state === LinkState.OK,
+		);
+		const skippedFragment = results.links.find((result) =>
+			result.url.endsWith('/target#skip'),
+		);
+		expect(target?.displayText).toBe('Only label');
+		expect(skippedFragment?.displayText).toBe('Only label');
+	});
+
+	it('should not GET a non-fragment target for fragment checking', async () => {
+		const mockPool = mockAgent.get('http://example.invalid');
+		mockPool
+			.intercept({ path: '/source.html', method: 'GET' })
+			.reply(200, '<link rel="canonical" href="/target">', {
+				headers: { 'content-type': 'text/html' },
+			});
+		mockPool
+			.intercept({ path: '/target', method: 'HEAD' })
+			.reply(200, '', { headers: { 'content-type': 'text/html' } });
+
+		const results = await check({
+			path: 'http://example.invalid/source.html',
+			checkFragments: true,
+		});
+
+		expect(results.passed).toBe(true);
+		expect(
+			results.links.find(
+				(result) => result.url === 'http://example.invalid/target',
+			)?.state,
+		).toBe(LinkState.OK);
+	});
+
+	it('should preserve first-source metadata for a cached result', async () => {
+		const mockPool = mockAgent.get('http://example.invalid');
+		mockPool
+			.intercept({ path: '/first.html', method: 'GET' })
+			.reply(200, '<link rel="canonical" href="/target">', {
+				headers: { 'content-type': 'text/html' },
+			});
+		mockPool
+			.intercept({ path: '/second.html', method: 'GET' })
+			.reply(200, '<a href="/target">Later label</a>', {
+				headers: { 'content-type': 'text/html' },
+			})
+			.delay(100);
+		mockPool.intercept({ path: '/target', method: 'HEAD' }).reply(200, '');
+
+		const checker = new LinkChecker();
+		let emittedTarget: LinkResult | undefined;
+		checker.on('link', (result) => {
+			if (result.url === 'http://example.invalid/target') {
+				emittedTarget = result;
+			}
+		});
+		const results = await checker.check({
+			path: [
+				'http://example.invalid/first.html',
+				'http://example.invalid/second.html',
+			],
+		});
+		const targetResults = results.links.filter(
+			(result) => result.url === 'http://example.invalid/target',
+		);
+		expect(targetResults).toHaveLength(1);
+		expect(targetResults[0].displayText).toBeUndefined();
+		expect(targetResults[0].parent).toBe('http://example.invalid/first.html');
+		expect(emittedTarget).toBe(targetResults[0]);
+	});
+
+	it('should preserve first-source metadata for a cached skipped result', async () => {
+		const mockPool = mockAgent.get('http://example.invalid');
+		mockPool
+			.intercept({ path: '/first.html', method: 'GET' })
+			.reply(200, '<link rel="canonical" href="/target">', {
+				headers: { 'content-type': 'text/html' },
+			});
+		mockPool
+			.intercept({ path: '/second.html', method: 'GET' })
+			.reply(200, '<a href="/target">Later label</a>', {
+				headers: { 'content-type': 'text/html' },
+			})
+			.delay(100);
+		mockPool.intercept({ path: '/target', method: 'HEAD' }).reply(999, '');
+		mockPool.intercept({ path: '/target', method: 'GET' }).reply(999, '');
+
+		const results = await check({
+			path: [
+				'http://example.invalid/first.html',
+				'http://example.invalid/second.html',
+			],
+		});
+		const targetResults = results.links.filter(
+			(result) => result.url === 'http://example.invalid/target',
+		);
+		expect(targetResults).toHaveLength(1);
+		expect(targetResults[0].state).toBe(LinkState.SKIPPED);
+		expect(targetResults[0].displayText).toBeUndefined();
+		expect(targetResults[0].parent).toBe('http://example.invalid/first.html');
 	});
 
 	it('should only try a link once', async () => {
@@ -115,6 +301,9 @@ describe('linkinator', () => {
 			results.links.filter((x) => x.state === LinkState.SKIPPED).length,
 			1,
 		);
+		expect(
+			results.links.find((x) => x.state === LinkState.SKIPPED)?.displayText,
+		).toBe('we should skip dis one');
 	});
 
 	it('should match linksToSkip against URL fragments', async () => {
@@ -259,6 +448,9 @@ describe('linkinator', () => {
 			results.links.filter((x) => x.state === LinkState.BROKEN).length,
 			1,
 		);
+		expect(
+			results.links.find((x) => x.state === LinkState.BROKEN)?.displayText,
+		).toBe('oh noes');
 	});
 
 	it('should detect relative urls with relative base', async () => {
@@ -1166,6 +1358,12 @@ describe('linkinator', () => {
 			parents[1]?.includes('pageB.html'),
 			'broken123 should be reported for pageB.html',
 		);
+
+		const displayTexts = broken123Links.map((x) => x.displayText).sort();
+		expect(displayTexts).toEqual([
+			'Broken Link 123 from A',
+			'Broken Link 123 from B',
+		]);
 	});
 
 	it('should resolve relative links correctly when URL has trailing slash', async () => {

--- a/test/test.index.ts
+++ b/test/test.index.ts
@@ -146,6 +146,40 @@ describe('linkinator', () => {
 		expect(skippedFragment?.displayText).toBe('Only label');
 	});
 
+	it('should not apply a fragment-skipped label to a non-anchor occurrence', async () => {
+		const mockPool = mockAgent.get('http://example.invalid');
+		mockPool
+			.intercept({ path: '/source.html', method: 'GET' })
+			.reply(
+				200,
+				[
+					'<link rel="canonical" href="/target">',
+					'<a href="/target#skip">Skipped label</a>',
+				].join(''),
+				{ headers: { 'content-type': 'text/html' } },
+			);
+		mockPool
+			.intercept({ path: '/target', method: 'HEAD' })
+			.reply(200, '', { headers: { 'content-type': 'text/html' } });
+
+		const results = await check({
+			path: 'http://example.invalid/source.html',
+			checkFragments: true,
+			fragmentsToSkip: ['^skip$'],
+		});
+		const target = results.links.find(
+			(result) =>
+				result.url === 'http://example.invalid/target' &&
+				result.state === LinkState.OK,
+		);
+		const skippedFragment = results.links.find((result) =>
+			result.url.endsWith('/target#skip'),
+		);
+		expect(target?.displayText).toBeUndefined();
+		expect(Object.hasOwn(target ?? {}, 'displayText')).toBe(false);
+		expect(skippedFragment?.displayText).toBe('Skipped label');
+	});
+
 	it('should not GET a non-fragment target for fragment checking', async () => {
 		const mockPool = mockAgent.get('http://example.invalid');
 		mockPool


### PR DESCRIPTION
Closes #70.

## Summary

- add optional `displayText` to API/link-event results using normalized descendant text from the source anchor
- preserve stable first-source metadata across page-level deduplication while preferring meaningful same-page anchor text
- carry display text through skipped, malformed, broken, repeated, and fragment results without changing the CSV schema
- make fragment validation concurrency-safe for late discovery, URL rewrites, encoded-equivalent fragments, and supplementary metadata failures
- enforce 100% coverage for changed production statements, branches, and functions in CI

## Verification

- `npm run coverage`: 327 tests across 19 files; 100% patch coverage
  - `src/index.ts`: 114/114 statements, 89/89 branches, 7/7 functions
  - `src/links.ts`: 15/15 statements, 14/14 branches, 1/1 function
- `npm run build`
- `npm run lint`
- built CLI end-to-end suite: 36/36 tests
- `npm run docs-test`: 17/17 live links
- two independent final code reviews: no findings

The repository-wide historical coverage baseline remains below 100%; this PR adds a durable diff-aware gate so all changed production code must be fully covered.
