### PR TITLE
feat: crawl sites from sitemaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ $ linkinator LOCATIONS [ --arguments ]
     --recurse, -r
         Recursively follow links on the same root domain.
 
+    --sitemap
+        Crawl every page listed in /sitemap.xml. Sitemap indexes are followed recursively.
+
+    --sitemap-url
+        Use an explicit sitemap URL. Can be specified multiple times, but cannot be combined with --sitemap.
+
     --check-css
         Extract and check URLs found in CSS properties (inline styles, <style> tags, and external CSS files).
         This includes url() functions, @import statements, and other CSS URL references.
@@ -238,6 +244,26 @@ Need to check a static site with clean URLs (extensionless links)?
 npx linkinator ./dist --recurse --clean-urls
 ```
 
+To scan every page declared by a site's sitemap without recursively discovering
+pages through links, use `--sitemap`:
+
+```bash
+npx linkinator https://example.com --sitemap
+```
+
+Sitemap indexes are followed recursively, including index entries that use
+query strings for pagination. For a custom location, use `--sitemap-url`; repeat
+the option to load multiple sitemaps. `--sitemap-url` cannot be combined with
+`--sitemap`:
+
+```bash
+npx linkinator https://example.com --sitemap-url https://example.com/custom-sitemap.xml
+```
+
+Sitemap mode scans the pages listed in the map and validates their links. If
+`--recurse` is also supplied, same-site pages linked from those seeds are crawled
+recursively as well.
+
 ### 🌰 Strict Link Checking
 
 Like a diligent squirrel inspecting every acorn before storing it for winter, you can configure linkinator to be *extremely* picky about your links. Here's how to go full squirrel:
@@ -262,6 +288,7 @@ All options are optional. It should look like this:
   "concurrency": 100,
   "config": "string",
   "recurse": true,
+  "sitemap": ["https://example.com/sitemap.xml"],
   "skip": "www.googleapis.com",
   "format": "json",
   "silent": true,
@@ -406,6 +433,7 @@ Asynchronous method that runs a site wide scan. Options come in the form of an o
 - `concurrency` (number) -  The number of connections to make simultaneously. Defaults to 100.
 - `port` (number) - When the `path` is provided as a local path on disk, the `port` on which to start the temporary web server.  Defaults to a random high range order port.
 - `recurse` (boolean) - By default, all scans are shallow.  Only the top level links on the requested page will be scanned.  By setting `recurse` to `true`, the crawler will follow all links on the page, and continue scanning links **on the same domain** for as long as it can go. Results are cached, so no worries about loops.
+- `sitemap` (boolean|string|string[]) - Use sitemap page URLs as initial crawl targets. Set to `true` to load `/sitemap.xml` from each HTTP `path`, or provide one or more explicit sitemap URLs. Sitemap indexes are followed recursively; combine with `recurse` to discover additional same-domain pages from those targets.
 - `checkCss` (boolean) - Extract and check URLs found in CSS properties (inline styles, `<style>` tags, and external CSS files when using `recurse`). This includes `url()` functions, `@import` statements, and other CSS URL references. Defaults to `false`.
 - `checkFragments` (boolean) - Validate fragment identifiers against server-rendered HTML. Defaults to `false`.
 - `fragmentsToSkip` (array | function) - Regular expression strings matched against decoded fragment identifiers, or an async function receiving the fragment and full URL. Matching fragments are reported as skipped while the underlying URL is still checked.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
 				"marked-gfm-heading-id": "^4.1.4",
 				"meow": "^14.0.0",
 				"mime": "^4.0.0",
+				"saxes": "6.0.0",
 				"srcset": "^5.0.0",
 				"undici": "^8.0.0"
 			},
@@ -2245,6 +2246,18 @@
 				"@rolldown/binding-win32-x64-msvc": "1.0.3"
 			}
 		},
+		"node_modules/saxes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"license": "ISC",
+			"dependencies": {
+				"xmlchars": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=v12.22.7"
+			}
+		},
 		"node_modules/semver": {
 			"version": "7.7.4",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -2672,6 +2685,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"license": "MIT"
 		},
 		"node_modules/yoctocolors": {
 			"version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"marked-gfm-heading-id": "^4.1.4",
 		"meow": "^14.0.0",
 		"mime": "^4.0.0",
+		"saxes": "6.0.0",
 		"srcset": "^5.0.0",
 		"undici": "^8.0.0"
 	},

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -61,6 +61,12 @@ const cli = meow(
 		--recurse, -r
 			Recursively follow links on the same root domain.
 
+		--sitemap
+			Crawl every page listed in /sitemap.xml. Sitemap indexes are followed recursively.
+
+		--sitemap-url
+			Use an explicit sitemap URL. Can be specified multiple times, but cannot be combined with --sitemap.
+
 		--check-css
 			Extract and check URLs found in CSS properties (inline styles, <style> tags, and external CSS files).
 			This includes url() functions, @import statements, and other CSS URL references.
@@ -147,6 +153,8 @@ const cli = meow(
 			config: { type: 'string' },
 			concurrency: { type: 'number' },
 			recurse: { type: 'boolean', shortFlag: 'r' },
+			sitemap: { type: 'boolean' },
+			sitemapUrl: { type: 'string', isMultiple: true },
 			skip: { type: 'string', shortFlag: 's', isMultiple: true },
 			statusCode: { type: 'string', isMultiple: true },
 			format: { type: 'string', shortFlag: 'f' },
@@ -205,6 +213,11 @@ async function main() {
 	// Type assertion needed because meow's type for cli.flags uses generic string
 	// but meow validates the 'choices' at runtime to ensure it's one of the valid values
 	flags = await getConfig(cli.flags as Flags);
+	if (flags.sitemap && flags.sitemapUrl) {
+		throw new Error(
+			'The sitemap and sitemap-url flags cannot be used together.',
+		);
+	}
 	if (
 		(flags.urlRewriteReplace && !flags.urlRewriteSearch) ||
 		(flags.urlRewriteSearch && !flags.urlRewriteReplace)
@@ -355,6 +368,7 @@ async function main() {
 	const options: CheckOptions = {
 		path: cli.input,
 		recurse: flags.recurse,
+		sitemap: flags.sitemapUrl ?? flags.sitemap,
 		timeout: Number(flags.timeout),
 		markdown: flags.markdown,
 		checkCss: flags.checkCss,

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,8 @@ export type Flags = {
 	concurrency?: number;
 	config?: string;
 	recurse?: boolean;
+	sitemap?: boolean | string | string[];
+	sitemapUrl?: string | string[];
 	skip?: string | string[];
 	format?: string;
 	silent?: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,11 @@ import {
 	type RequestResponse,
 } from './request.js';
 import { startWebServer, stopWebServer } from './server.js';
+import {
+	type ParsedSitemap,
+	parseSitemap,
+	SitemapXmlError,
+} from './sitemap.js';
 import { bufferStream, drainStream, toNodeReadable } from './stream-utils.js';
 
 const STATIC_SERVER_HOST = '127.0.0.1';
@@ -83,7 +88,144 @@ type CrawlOptions = {
 	retryErrors: boolean;
 	retryErrorsCount: number;
 	retryErrorsJitter: number;
+	requestLimiter: RequestLimiter;
+	signal: AbortSignal;
 };
+
+type CrawlTarget = {
+	url: string;
+	rootPath: string;
+};
+
+type LoadedSitemap = {
+	baseUrl: string;
+	sitemap: ParsedSitemap;
+	sourceUrl: string;
+};
+
+async function mapConcurrently<T, R>(
+	values: T[],
+	concurrency: number,
+	mapper: (value: T, signal: AbortSignal) => Promise<R>,
+): Promise<R[]> {
+	const results = new Array<R>(values.length);
+	const controller = new AbortController();
+	let nextIndex = 0;
+	let firstError: unknown;
+	async function worker() {
+		while (firstError === undefined) {
+			const index = nextIndex++;
+			if (index >= values.length) {
+				return;
+			}
+			try {
+				results[index] = await mapper(values[index], controller.signal);
+			} catch (error) {
+				if (firstError === undefined) {
+					firstError = error;
+					controller.abort();
+				}
+			}
+		}
+	}
+
+	await Promise.all(
+		Array.from({ length: Math.min(concurrency, values.length) }, () =>
+			worker(),
+		),
+	);
+	if (firstError !== undefined) {
+		throw firstError;
+	}
+	return results;
+}
+
+class RequestLimiter {
+	private active = 0;
+	private readonly waiters: Array<() => void> = [];
+
+	constructor(private readonly concurrency: number) {}
+
+	private async acquire(signal: AbortSignal) {
+		signal.throwIfAborted();
+		if (this.active >= this.concurrency) {
+			await new Promise<void>((resolve, reject) => {
+				const onAvailable = () => {
+					signal.removeEventListener('abort', onAbort);
+					resolve();
+				};
+				const onAbort = () => {
+					const index = this.waiters.indexOf(onAvailable);
+					if (index >= 0) {
+						this.waiters.splice(index, 1);
+						reject(signal.reason);
+					}
+				};
+				this.waiters.push(onAvailable);
+				signal.addEventListener('abort', onAbort, { once: true });
+			});
+		} else {
+			this.active++;
+		}
+	}
+
+	private release() {
+		const next = this.waiters.shift();
+		if (next) {
+			next();
+		} else {
+			this.active--;
+		}
+	}
+
+	async run<T>(
+		signal: AbortSignal,
+		operation: (pause: <R>(wait: () => Promise<R>) => Promise<R>) => Promise<T>,
+	): Promise<T> {
+		await this.acquire(signal);
+		let acquired = true;
+		const pause = async <R>(wait: () => Promise<R>) => {
+			this.release();
+			acquired = false;
+			try {
+				return await wait();
+			} finally {
+				if (!signal.aborted) {
+					await this.acquire(signal);
+					acquired = true;
+				}
+				signal.throwIfAborted();
+			}
+		};
+
+		try {
+			signal.throwIfAborted();
+			return await operation(pause);
+		} finally {
+			if (acquired) {
+				this.release();
+			}
+		}
+	}
+}
+
+async function waitForRetry(milliseconds: number, signal: AbortSignal) {
+	signal.throwIfAborted();
+	await new Promise<void>((resolve, reject) => {
+		const onAbort = () => {
+			clearTimeout(timer);
+			reject(signal.reason);
+		};
+		const timer = setTimeout(
+			() => {
+				signal.removeEventListener('abort', onAbort);
+				resolve();
+			},
+			Math.max(0, milliseconds),
+		);
+		signal.addEventListener('abort', onAbort, { once: true });
+	});
+}
 
 /**
  * Instance class used to perform a crawl job.
@@ -106,13 +248,19 @@ export class LinkChecker extends EventEmitter {
 		options.pendingChecks.set(options.url.href, completion);
 		options.queue.add(async () => {
 			try {
-				await this.crawl(options);
+				await this.runCrawl(options);
 			} finally {
 				resolveCompletion();
 			}
 		});
 
 		return completion;
+	}
+
+	private runCrawl(options: CrawlOptions) {
+		return options.requestLimiter.run(options.signal, () =>
+			this.crawl(options),
+		);
 	}
 
 	on(event: 'link', listener: (result: LinkResult) => void): this;
@@ -181,6 +329,8 @@ export class LinkChecker extends EventEmitter {
 		const queue = new Queue({
 			concurrency: options.concurrency || 100,
 		});
+		const requestLimiter = new RequestLimiter(options.concurrency || 100);
+		const runController = new AbortController();
 
 		const results: LinkResult[] = [];
 		const initCache = new Set<string>();
@@ -189,8 +339,11 @@ export class LinkChecker extends EventEmitter {
 		const delayCache = new Map<string, number>();
 		const retryErrorsCache = new Map<string, number>();
 
-		for (const path of options.path) {
-			const url = new URL(path);
+		const enqueueTarget = (target: CrawlTarget) => {
+			const url = new URL(target.url);
+			if (initCache.has(url.href)) {
+				return;
+			}
 			initCache.add(url.href);
 
 			this.enqueueCrawl({
@@ -204,12 +357,36 @@ export class LinkChecker extends EventEmitter {
 				delayCache,
 				retryErrorsCache,
 				queue,
-				rootPath: path,
+				rootPath: target.rootPath,
 				retry: Boolean(options_.retry),
 				retryErrors: Boolean(options_.retryErrors),
 				retryErrorsCount: options_.retryErrorsCount ?? 5,
 				retryErrorsJitter: options_.retryErrorsJitter ?? 3000,
+				requestLimiter,
+				signal: runController.signal,
 			});
+		};
+		if (options.sitemap) {
+			try {
+				await this.discoverSitemapTargets(
+					options,
+					options.sitemap,
+					enqueueTarget,
+					requestLimiter,
+					runController.signal,
+				);
+			} catch (error) {
+				// Sitemap discovery starts page checks as soon as URL sets arrive. Do
+				// not let those checks outlive a failed check() call.
+				runController.abort(error);
+				queue.runPendingNow();
+				await queue.onIdle();
+				throw error;
+			}
+		} else {
+			for (const url of options.path) {
+				enqueueTarget({ url, rootPath: url });
+			}
 		}
 
 		await queue.onIdle();
@@ -225,6 +402,248 @@ export class LinkChecker extends EventEmitter {
 		return result;
 	}
 
+	private async discoverSitemapTargets(
+		options: InternalCheckOptions,
+		configuredSitemap: true | string | string[],
+		onTarget: (target: CrawlTarget) => void,
+		requestLimiter: RequestLimiter,
+		runSignal: AbortSignal,
+	): Promise<void> {
+		// processOptions normalizes paths before this method is called.
+		const paths = options.path as string[];
+		const sitemapUrls =
+			configuredSitemap === true
+				? paths.map((url) => new URL('/sitemap.xml', url).href)
+				: typeof configuredSitemap === 'string'
+					? [configuredSitemap]
+					: configuredSitemap;
+		let pending = [...new Set(sitemapUrls)];
+		const visited = new Set<string>();
+		const pageUrls = new Set<string>();
+
+		while (pending.length > 0) {
+			const batch: string[] = [];
+			for (const sitemapUrl of pending) {
+				let normalizedUrl: string;
+				try {
+					normalizedUrl = new URL(this.rewriteUrl(sitemapUrl, options)).href;
+				} catch {
+					throw new Error(`Invalid sitemap URL: ${sitemapUrl}`);
+				}
+				if (!isHttpUrl(normalizedUrl)) {
+					throw new Error(`Invalid sitemap URL protocol: ${normalizedUrl}`);
+				}
+				if (!visited.has(normalizedUrl)) {
+					visited.add(normalizedUrl);
+					batch.push(normalizedUrl);
+				}
+			}
+			pending = [];
+
+			await mapConcurrently(
+				batch,
+				options.concurrency || 100,
+				async (url, signal) => {
+					const combinedSignal = AbortSignal.any([signal, runSignal]);
+					const { baseUrl, sitemap, sourceUrl } = await requestLimiter.run(
+						combinedSignal,
+						(pause) => this.loadSitemap(url, options, combinedSignal, pause),
+					);
+					for (const location of sitemap.locations) {
+						let resolvedLocation: string;
+						try {
+							resolvedLocation = new URL(location, baseUrl).href;
+						} catch {
+							throw new Error(
+								`Invalid URL in sitemap ${sourceUrl}: ${location}`,
+							);
+						}
+						if (!isHttpUrl(resolvedLocation)) {
+							throw new Error(
+								`Invalid URL protocol in sitemap ${sourceUrl}: ${location}`,
+							);
+						}
+						if (sitemap.type === 'index') {
+							pending.push(resolvedLocation);
+							continue;
+						}
+
+						let rewrittenLocation: string;
+						try {
+							rewrittenLocation = new URL(
+								this.rewriteUrl(resolvedLocation, options),
+							).href;
+						} catch {
+							throw new Error(
+								`Invalid rewritten URL from sitemap ${sourceUrl}: ${location}`,
+							);
+						}
+						if (!isHttpUrl(rewrittenLocation)) {
+							throw new Error(
+								`Invalid rewritten URL protocol in sitemap ${sourceUrl}: ${location}`,
+							);
+						}
+						if (!pageUrls.has(rewrittenLocation)) {
+							pageUrls.add(rewrittenLocation);
+							onTarget({
+								url: rewrittenLocation,
+								rootPath: new URL('/', rewrittenLocation).href,
+							});
+						}
+					}
+				},
+			);
+		}
+
+		if (pageUrls.size === 0) {
+			throw new Error('The configured sitemap did not contain any page URLs.');
+		}
+	}
+
+	private async loadSitemap(
+		normalizedUrl: string,
+		options: InternalCheckOptions,
+		signal: AbortSignal,
+		pauseLimiter: <R>(wait: () => Promise<R>) => Promise<R>,
+	): Promise<LoadedSitemap> {
+		const redirectMode = options.redirects === 'error' ? 'manual' : 'follow';
+		const processRedirectTarget =
+			redirectMode === 'follow' &&
+			(this.hasSkipRules(options) ||
+				Boolean(options.urlRewriteExpressions?.length))
+				? (url: string) => this.processRedirectTarget(url, options)
+				: undefined;
+		let response: RequestResponse;
+		let errorRetries = 0;
+		for (;;) {
+			try {
+				response = await makeRequest('GET', normalizedUrl, {
+					headers: options.headers,
+					timeout: options.timeout,
+					redirect: redirectMode,
+					allowInsecureCerts: options.allowInsecureCerts,
+					processRedirectTarget,
+					signal,
+				});
+			} catch (error) {
+				if (
+					signal.aborted ||
+					!options.retryErrors ||
+					errorRetries >= (options.retryErrorsCount ?? 5)
+				) {
+					throw error;
+				}
+				errorRetries++;
+				const retryDelay =
+					2 ** errorRetries * 1000 +
+					Math.random() * (options.retryErrorsJitter ?? 3000);
+				this.emit('retry', {
+					url: normalizedUrl,
+					status: 0,
+					secondsUntilRetry: Math.round(retryDelay / 1000),
+				} satisfies RetryInfo);
+				await pauseLimiter(() => waitForRetry(retryDelay, signal));
+				continue;
+			}
+
+			const retryAfterRaw = response.headers['retry-after'];
+			if (options.retry && response.status === 429 && retryAfterRaw) {
+				const retryAt = this.parseRetryAfter(retryAfterRaw);
+				if (!Number.isNaN(retryAt)) {
+					const retryDelay = Math.max(0, retryAt - Date.now());
+					await drainStream(response.body);
+					this.emit('retry', {
+						url: normalizedUrl,
+						status: response.status,
+						secondsUntilRetry: Math.round(retryDelay / 1000),
+					} satisfies RetryInfo);
+					await pauseLimiter(() => waitForRetry(retryDelay, signal));
+					continue;
+				}
+			}
+
+			if (
+				options.retryErrors &&
+				(response.status >= 500 || response.status === 429) &&
+				errorRetries < (options.retryErrorsCount ?? 5)
+			) {
+				errorRetries++;
+				const retryDelay =
+					2 ** errorRetries * 1000 +
+					Math.random() * (options.retryErrorsJitter ?? 3000);
+				await drainStream(response.body);
+				this.emit('retry', {
+					url: normalizedUrl,
+					status: response.status,
+					secondsUntilRetry: Math.round(retryDelay / 1000),
+				} satisfies RetryInfo);
+				await pauseLimiter(() => waitForRetry(retryDelay, signal));
+				continue;
+			}
+
+			if (response.redirectSkipped) {
+				throw new Error(
+					`Sitemap redirected to a URL excluded by a skip rule: ${response.redirectSkipped}`,
+				);
+			}
+			if (response.status < 200 || response.status >= 300) {
+				await drainStream(response.body);
+				throw new Error(
+					`Unable to load sitemap ${normalizedUrl}: HTTP ${response.status}`,
+				);
+			}
+			if (!response.body) {
+				throw new Error(`Sitemap ${normalizedUrl} returned an empty response.`);
+			}
+
+			let sitemap: ParsedSitemap;
+			try {
+				sitemap = await parseSitemap(toNodeReadable(response.body));
+			} catch (error) {
+				if (
+					!(error instanceof SitemapXmlError) &&
+					!signal.aborted &&
+					options.retryErrors &&
+					errorRetries < (options.retryErrorsCount ?? 5)
+				) {
+					errorRetries++;
+					const retryDelay =
+						2 ** errorRetries * 1000 +
+						Math.random() * (options.retryErrorsJitter ?? 3000);
+					this.emit('retry', {
+						url: normalizedUrl,
+						status: 0,
+						secondsUntilRetry: Math.round(retryDelay / 1000),
+					} satisfies RetryInfo);
+					await pauseLimiter(() => waitForRetry(retryDelay, signal));
+					continue;
+				}
+				const details = error instanceof Error ? `: ${error.message}` : '';
+				throw new Error(`Unable to parse sitemap ${normalizedUrl}${details}`, {
+					cause: error,
+				});
+			}
+
+			if (
+				options.redirects === 'warn' &&
+				response.url &&
+				response.url !== normalizedUrl
+			) {
+				this.emit('redirect', {
+					url: normalizedUrl,
+					targetUrl: response.url,
+					status: response.status,
+					isNonStandard: false,
+				});
+			}
+			return {
+				baseUrl: response.url || normalizedUrl,
+				sitemap,
+				sourceUrl: normalizedUrl,
+			};
+		}
+	}
+
 	/**
 	 * Crawl a given url with the provided options.
 	 * @pram opts List of options used to do the crawl
@@ -232,6 +651,9 @@ export class LinkChecker extends EventEmitter {
 	 * @returns A list of crawl results consisting of urls and status codes
 	 */
 	async crawl(options: CrawlOptions): Promise<void> {
+		if (options.signal.aborted) {
+			return;
+		}
 		options.url.href = this.rewriteUrl(options.url.href, options.checkOptions);
 
 		if (await this.shouldSkipUrl(options.url.href, options.checkOptions)) {
@@ -248,7 +670,7 @@ export class LinkChecker extends EventEmitter {
 			if (timeout > Date.now()) {
 				options.queue.add(
 					async () => {
-						await this.crawl(options);
+						await this.runCrawl(options);
 					},
 					{
 						delay: timeout - Date.now(),
@@ -279,6 +701,7 @@ export class LinkChecker extends EventEmitter {
 			redirect: redirectMode,
 			allowInsecureCerts: options.checkOptions.allowInsecureCerts,
 			processRedirectTarget,
+			signal: options.signal,
 		} as const;
 
 		try {
@@ -394,6 +817,9 @@ export class LinkChecker extends EventEmitter {
 
 		// If retryErrors is enabled, retry 5xx and 0 status (which indicates
 		// a network error likely occurred) or 429 without retry-after data:
+		if (options.signal.aborted) {
+			return;
+		}
 		if (this.shouldRetryOnError(status, options)) {
 			return;
 		}
@@ -756,6 +1182,8 @@ export class LinkChecker extends EventEmitter {
 						retryErrors: options.retryErrors,
 						retryErrorsCount: options.retryErrorsCount,
 						retryErrorsJitter: options.retryErrorsJitter,
+						requestLimiter: options.requestLimiter,
+						signal: options.signal,
 					});
 				} else {
 					// URL is being checked or has been checked
@@ -986,7 +1414,7 @@ export class LinkChecker extends EventEmitter {
 
 		options.queue.add(
 			async () => {
-				await this.crawl(options);
+				await this.runCrawl(options);
 			},
 			{
 				delay: retryAfter - Date.now(),
@@ -1035,7 +1463,7 @@ export class LinkChecker extends EventEmitter {
 
 		options.queue.add(
 			async () => {
-				await this.crawl(options);
+				await this.runCrawl(options);
 			},
 			{
 				delay: retryAfter,
@@ -1077,6 +1505,11 @@ function isHtml(response: HttpResponse): boolean {
 function isCss(response: HttpResponse): boolean {
 	const contentType = (response.headers['content-type'] as string) || '';
 	return Boolean(/text\/css/g.test(contentType));
+}
+
+function isHttpUrl(url: string): boolean {
+	const protocol = new URL(url).protocol;
+	return protocol === 'http:' || protocol === 'https:';
 }
 
 /**

--- a/src/options.ts
+++ b/src/options.ts
@@ -15,6 +15,7 @@ export type CheckOptions = {
 	port?: number;
 	path: string | string[];
 	recurse?: boolean;
+	sitemap?: boolean | string | string[];
 	timeout?: number;
 	markdown?: boolean;
 	linksToSkip?: string[] | ((link: string) => Promise<boolean>);
@@ -131,6 +132,10 @@ export async function processOptions(
 		throw new Error(
 			"'serverRoot' cannot be defined when the 'path' points to an HTTP endpoint.",
 		);
+	}
+
+	if (options.sitemap && !isUrlType) {
+		throw new Error("'sitemap' can only be used with HTTP paths.");
 	}
 
 	const headers = options.headers ?? {};

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -55,6 +55,16 @@ export class Queue extends EventEmitter {
 		});
 	}
 
+	/** Remove retry delays so an aborted run can drain queued work promptly. */
+	runPendingNow() {
+		const now = Date.now();
+		for (const item of this.q) {
+			item.timeToRun = now;
+		}
+		this.cancelWakeup();
+		this.tick();
+	}
+
 	private tick() {
 		// Check if we're complete
 		if (this.activeFunctions === 0 && this.q.length === 0) {

--- a/src/request.ts
+++ b/src/request.ts
@@ -26,6 +26,7 @@ type ProcessRedirectTarget = (url: string) => Promise<RedirectTarget>;
 type RequestOptions = {
 	headers?: Record<string, string>;
 	timeout?: number;
+	signal?: AbortSignal;
 	redirect: 'follow' | 'manual';
 	allowInsecureCerts?: boolean;
 	processRedirectTarget?: ProcessRedirectTarget;
@@ -71,9 +72,13 @@ export async function makeRequest(
 	let currentUrl = url;
 	let currentHeaders = { ...DEFAULT_HEADERS, ...options.headers };
 	const processRedirectTarget = options.processRedirectTarget;
-	const signal = options.timeout
+	const timeoutSignal = options.timeout
 		? AbortSignal.timeout(options.timeout)
 		: undefined;
+	const signal =
+		options.signal && timeoutSignal
+			? AbortSignal.any([options.signal, timeoutSignal])
+			: (options.signal ?? timeoutSignal);
 
 	for (let redirectCount = 0; ; redirectCount++) {
 		const requestOptions: RequestInit = {

--- a/src/saxes-parser.cjs
+++ b/src/saxes-parser.cjs
@@ -1,0 +1,19 @@
+// @ts-nocheck
+// A CommonJS bridge keeps saxes' complete class prototype in Bun standalone
+// binaries. A direct ESM named import is over-aggressively tree-shaken by Bun.
+const saxes = require('saxes');
+
+/**
+ * @typedef {{local: string}} SaxesTag
+ * @typedef {{
+ *   on(event: 'cdata' | 'text', handler: (text: string) => void): void;
+ *   on(event: 'closetag' | 'opentag', handler: (tag: SaxesTag) => void): void;
+ *   on(event: 'error', handler: (error: Error) => void): void;
+ *   write(chunk: string): SaxesParserInstance;
+ *   close(): SaxesParserInstance;
+ * }} SaxesParserInstance
+ * @typedef {new (options: {xmlns: true}) => SaxesParserInstance} SaxesParserConstructor
+ */
+
+/** @type {SaxesParserConstructor} */
+exports.SaxesParser = saxes.SaxesParser;

--- a/src/sitemap.ts
+++ b/src/sitemap.ts
@@ -1,0 +1,155 @@
+import { Readable } from 'node:stream';
+import { StringDecoder } from 'node:string_decoder';
+import { createGunzip } from 'node:zlib';
+import { SaxesParser } from './saxes-parser.cjs';
+
+export type ParsedSitemap = {
+	type: 'index' | 'urlset';
+	locations: string[];
+};
+
+export class SitemapXmlError extends Error {
+	constructor(message: string, options?: ErrorOptions) {
+		super(message, options);
+		this.name = 'SitemapXmlError';
+	}
+}
+
+async function decodeSitemapSource(source: Readable): Promise<Readable> {
+	const iterator = source[Symbol.asyncIterator]();
+	const leadingChunks: Buffer[] = [];
+	let leadingLength = 0;
+	while (leadingLength < 2) {
+		const next = await iterator.next();
+		if (next.done) {
+			break;
+		}
+		const chunk = Buffer.isBuffer(next.value)
+			? next.value
+			: Buffer.from(next.value);
+		leadingChunks.push(chunk);
+		leadingLength += chunk.length;
+	}
+
+	async function* replayChunks() {
+		try {
+			for (const chunk of leadingChunks) {
+				yield chunk;
+			}
+			for (;;) {
+				const next = await iterator.next();
+				if (next.done) {
+					return;
+				}
+				yield next.value;
+			}
+		} finally {
+			await iterator.return?.();
+		}
+	}
+
+	const replay = Readable.from(replayChunks());
+	const signature = Buffer.concat(leadingChunks, leadingLength).subarray(0, 2);
+	if (signature[0] !== 0x1f || signature[1] !== 0x8b) {
+		return replay;
+	}
+
+	const gunzip = createGunzip();
+	replay.on('error', (error) => gunzip.destroy(error));
+	return replay.pipe(gunzip);
+}
+
+/** Parse a sitemap URL set or sitemap index from an XML stream. */
+export async function parseSitemap(source: Readable): Promise<ParsedSitemap> {
+	const elements: string[] = [];
+	const locations: string[] = [];
+	let rootElement: string | undefined;
+	let locationText = '';
+	const decoder = new StringDecoder('utf8');
+	const parser = new SaxesParser({ xmlns: true });
+
+	parser.on('opentag', (tag) => {
+		const element = tag.local.toLowerCase();
+		rootElement ??= element;
+		if (
+			elements.length === 1 &&
+			((rootElement === 'urlset' && element === 'sitemap') ||
+				(rootElement === 'sitemapindex' && element === 'url'))
+		) {
+			throw new SitemapXmlError(
+				`Invalid <${element}> entry inside <${rootElement}>.`,
+			);
+		}
+		elements.push(element);
+		if (element === 'loc') {
+			locationText = '';
+		}
+	});
+	const appendText = (text: string) => {
+		if (elements.at(-1) === 'loc') {
+			locationText += text;
+		}
+	};
+	parser.on('text', appendText);
+	parser.on('cdata', appendText);
+	parser.on('closetag', (tag) => {
+		const element = tag.local.toLowerCase();
+		if (element === 'loc') {
+			const parent = elements.at(-2);
+			const grandparent = elements.at(-3);
+			const expectedParent =
+				rootElement === 'urlset'
+					? 'url'
+					: rootElement === 'sitemapindex'
+						? 'sitemap'
+						: undefined;
+			if (
+				(parent === 'url' || parent === 'sitemap') &&
+				(parent !== expectedParent || grandparent !== rootElement)
+			) {
+				throw new SitemapXmlError(
+					`Invalid <${parent}> entry inside <${rootElement}>.`,
+				);
+			}
+			if (parent === expectedParent && grandparent === rootElement) {
+				const location = locationText.trim();
+				if (location) {
+					locations.push(location);
+				}
+			}
+			locationText = '';
+		}
+		elements.pop();
+	});
+	parser.on('error', (error) => {
+		throw new SitemapXmlError(error.message, { cause: error });
+	});
+
+	const decodedSource = await decodeSitemapSource(source);
+	try {
+		for await (const chunk of decodedSource) {
+			parser.write(
+				decoder.write(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)),
+			);
+		}
+		parser.write(decoder.end()).close();
+	} catch (error) {
+		if (error instanceof SitemapXmlError) {
+			throw error;
+		}
+		throw error;
+	}
+
+	if (rootElement !== 'urlset' && rootElement !== 'sitemapindex') {
+		throw new SitemapXmlError(
+			`Expected a sitemap <urlset> or <sitemapindex> root element, but found ${
+				rootElement ? `<${rootElement}>` : 'an empty document'
+			}`,
+		);
+	}
+
+	return {
+		type: rootElement === 'sitemapindex' ? 'index' : 'urlset',
+		locations,
+	};
+}

--- a/test/test.cli.ts
+++ b/test/test.cli.ts
@@ -67,6 +67,66 @@ describe('cli', () => {
 		assert.match(response.stderr, /Successfully scanned/);
 	});
 
+	it('should crawl sitemap pages from the CLI', async () => {
+		let rootUrl = '';
+		server = http.createServer((request, response) => {
+			if (
+				request.url === '/sitemap.xml' ||
+				request.url === '/custom-sitemap.xml'
+			) {
+				response.setHeader('content-type', 'application/xml');
+				response.end(
+					`<urlset><url><loc>${rootUrl}/from-sitemap</loc></url></urlset>`,
+				);
+				return;
+			}
+			response.setHeader('content-type', 'text/html');
+			response.end('ok');
+		});
+		await new Promise<void>((resolve, reject) => {
+			server.once('error', reject).listen(0, '127.0.0.1', resolve);
+		});
+		const { port } = server.address() as AddressInfo;
+		rootUrl = `http://127.0.0.1:${port}`;
+
+		for (const sitemapArguments of [
+			['--sitemap'],
+			['--sitemap-url', `${rootUrl}/custom-sitemap.xml`],
+		]) {
+			const response = await execa(node, [
+				linkinator,
+				rootUrl,
+				...sitemapArguments,
+				'--format',
+				'json',
+			]);
+			const result = JSON.parse(response.stdout) as {
+				links: LinkResult[];
+			};
+			assert.strictEqual(result.links[0].url, `${rootUrl}/from-sitemap`);
+		}
+	});
+
+	it('should reject conflicting sitemap CLI flags', async () => {
+		const response = await execa(
+			node,
+			[
+				linkinator,
+				'https://example.com',
+				'--sitemap',
+				'--sitemap-url',
+				'https://example.com/custom-sitemap.xml',
+			],
+			{ reject: false },
+		);
+
+		assert.strictEqual(response.exitCode, 1);
+		assert.match(
+			response.stderr,
+			/The sitemap and sitemap-url flags cannot be used together/,
+		);
+	});
+
 	it('should show help if no params are provided', async () => {
 		const response = await execa(node, [linkinator], {
 			reject: false,

--- a/test/test.queue.ts
+++ b/test/test.queue.ts
@@ -56,6 +56,29 @@ describe('Queue', () => {
 		}
 	});
 
+	it('can run delayed work immediately when draining an aborted run', async () => {
+		vi.useFakeTimers();
+		try {
+			const queue = new Queue({ concurrency: 1 });
+			let ran = false;
+			queue.add(
+				async () => {
+					ran = true;
+				},
+				{ delay: 60_000 },
+			);
+
+			queue.runPendingNow();
+			await vi.advanceTimersByTimeAsync(0);
+			await queue.onIdle();
+
+			assert.isTrue(ran);
+			assert.strictEqual(vi.getTimerCount(), 0);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it('does not lose delayed work when active work completes', async () => {
 		vi.useFakeTimers();
 		try {

--- a/test/test.sitemap.ts
+++ b/test/test.sitemap.ts
@@ -1,0 +1,1162 @@
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { Readable } from 'node:stream';
+import { gzipSync } from 'node:zlib';
+import { afterEach, assert, describe, expect, it } from 'vitest';
+import { check, LinkChecker, LinkState } from '../src/index.js';
+import { parseSitemap } from '../src/sitemap.js';
+
+describe('sitemap parsing', () => {
+	it('parses namespaced URL sets and decodes entities', async () => {
+		const sitemap = await parseSitemap(
+			Readable.from(`<?xml version="1.0"?>
+				<sm:urlset xmlns:sm="http://www.sitemaps.org/schemas/sitemap/0.9">
+					<sm:url><sm:loc>https://example.com/a?x=1&amp;y=2</sm:loc></sm:url>
+					<sm:url><sm:loc>https://example.com/b</sm:loc></sm:url>
+				</sm:urlset>`),
+		);
+
+		assert.deepStrictEqual(sitemap, {
+			type: 'urlset',
+			locations: ['https://example.com/a?x=1&y=2', 'https://example.com/b'],
+		});
+	});
+
+	it('rejects XML that is not a sitemap', async () => {
+		await expect(
+			parseSitemap(Readable.from('<feed><link>nope</link></feed>')),
+		).rejects.toThrow(/Expected a sitemap/);
+	});
+
+	it('rejects an empty document', async () => {
+		await expect(parseSitemap(Readable.from(''))).rejects.toThrow(
+			/root element/,
+		);
+	});
+
+	it('ignores blank and extension location elements', async () => {
+		const sitemap = await parseSitemap(
+			Readable.from(`<urlset>
+				<loc>https://example.com/not-a-url-entry</loc>
+				<url><loc>  </loc></url>
+				<url xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+					<loc>https://example.com/page</loc>
+					<image:image><image:loc>https://example.com/image.jpg</image:loc></image:image>
+				</url>
+			</urlset>`),
+		);
+
+		assert.deepStrictEqual(sitemap.locations, ['https://example.com/page']);
+	});
+
+	it('rejects malformed or truncated XML', async () => {
+		await expect(
+			parseSitemap(
+				Readable.from('<urlset><url><loc>https://example.com</url></urlset>'),
+			),
+		).rejects.toThrow();
+		await expect(
+			parseSitemap(Readable.from('<urlset><url><loc>https://example.com')),
+		).rejects.toThrow();
+		await expect(
+			parseSitemap(Readable.from('<urlset><url value=unquoted/></urlset>')),
+		).rejects.toThrow();
+		await expect(
+			parseSitemap(
+				Readable.from('<urlset><url value="a" value="b"/></urlset>'),
+			),
+		).rejects.toThrow();
+		await expect(
+			parseSitemap(Readable.from('<urlset></urlset><urlset></urlset>')),
+		).rejects.toThrow();
+		await expect(
+			parseSitemap(
+				Readable.from(
+					'<urlset><url><loc>https://example.com/&bogus;</loc></url></urlset>',
+				),
+			),
+		).rejects.toThrow();
+		await expect(
+			parseSitemap(Readable.from('garbage<urlset/>')),
+		).rejects.toThrow();
+		await expect(
+			parseSitemap(Readable.from('<urlset/>garbage')),
+		).rejects.toThrow();
+
+		let sourceClosed = false;
+		const malformedStream = Readable.from(
+			(async function* () {
+				try {
+					yield '<urlset></wrong-root>';
+					yield '<never-reached/>';
+				} finally {
+					sourceClosed = true;
+				}
+			})(),
+		);
+		await expect(parseSitemap(malformedStream)).rejects.toThrow();
+		assert.ok(sourceClosed);
+	});
+
+	it('rejects entries that do not match the sitemap root type', async () => {
+		await expect(
+			parseSitemap(
+				Readable.from(
+					'<urlset><sitemap><loc>https://example.com/child.xml</loc></sitemap></urlset>',
+				),
+			),
+		).rejects.toThrow(/Invalid <sitemap> entry inside <urlset>/);
+		await expect(
+			parseSitemap(
+				Readable.from(
+					'<sitemapindex><url><loc>https://example.com/page</loc></url></sitemapindex>',
+				),
+			),
+		).rejects.toThrow(/Invalid <url> entry inside <sitemapindex>/);
+		await expect(
+			parseSitemap(Readable.from('<urlset><sitemap/></urlset>')),
+		).rejects.toThrow(/Invalid <sitemap> entry inside <urlset>/);
+		await expect(
+			parseSitemap(Readable.from('<sitemapindex><url/></sitemapindex>')),
+		).rejects.toThrow(/Invalid <url> entry inside <sitemapindex>/);
+		await expect(
+			parseSitemap(
+				Readable.from(
+					'<urlset><wrapper><url><loc>https://example.com</loc></url></wrapper></urlset>',
+				),
+			),
+		).rejects.toThrow(/Invalid <url> entry inside <urlset>/);
+	});
+
+	it('rejects source stream errors', async () => {
+		const source = new Readable({
+			read() {
+				this.destroy(new Error('socket reset'));
+			},
+		});
+
+		await expect(parseSitemap(source)).rejects.toThrow(/socket reset/);
+
+		const partialSource = Readable.from(
+			(async function* () {
+				yield '<urlset>';
+				throw new Error('stream interrupted');
+			})(),
+		);
+		await expect(parseSitemap(partialSource)).rejects.toThrow(
+			/stream interrupted/,
+		);
+
+		const compressedSource = Readable.from(
+			(async function* () {
+				yield Buffer.from([0x1f, 0x8b]);
+				throw new Error('compressed stream interrupted');
+			})(),
+		);
+		await expect(parseSitemap(compressedSource)).rejects.toThrow(
+			/compressed stream interrupted|unexpected end/i,
+		);
+	});
+
+	it('streams gzip-compressed sitemaps', async () => {
+		const sitemap = await parseSitemap(
+			Readable.from(
+				gzipSync(
+					'<urlset><url><loc>https://example.com/compressed</loc></url></urlset>',
+				),
+			),
+		);
+
+		assert.deepStrictEqual(sitemap.locations, [
+			'https://example.com/compressed',
+		]);
+	});
+
+	it('parses the protocol maximum of 50,000 page entries', async () => {
+		const pageCount = 50_000;
+		const source = Readable.from(
+			`<urlset>${Array.from(
+				{ length: pageCount },
+				(_, index) => `<url><loc>https://example.com/page-${index}</loc></url>`,
+			).join('')}</urlset>`,
+		);
+
+		const sitemap = await parseSitemap(source);
+
+		assert.strictEqual(sitemap.locations.length, pageCount);
+		assert.strictEqual(sitemap.locations[0], 'https://example.com/page-0');
+		assert.strictEqual(
+			sitemap.locations.at(-1),
+			'https://example.com/page-49999',
+		);
+	});
+});
+
+describe('sitemap crawling', () => {
+	let server: http.Server | undefined;
+
+	afterEach(async () => {
+		if (server) {
+			await new Promise<void>((resolve, reject) => {
+				server?.close((error) => (error ? reject(error) : resolve()));
+			});
+			server = undefined;
+		}
+	});
+
+	it('crawls pages from nested sitemap indexes without recursive discovery', async () => {
+		const requestedPaths: string[] = [];
+		let rootUrl = '';
+		server = http.createServer((request, response) => {
+			const requestUrl = request.url || '/';
+			requestedPaths.push(requestUrl);
+			response.setHeader('content-type', 'text/html');
+
+			switch (requestUrl) {
+				case '/sitemap.xml': {
+					response.setHeader('content-type', 'application/xml');
+					response.end(`<sitemapindex>
+						<sitemap><loc>${rootUrl}/sitemap.xml?page=1</loc></sitemap>
+						<sitemap><loc>${rootUrl}/sitemap.xml?page=2</loc></sitemap>
+					</sitemapindex>`);
+					break;
+				}
+				case '/sitemap.xml?page=1': {
+					response.setHeader('content-type', 'application/xml');
+					response.end(`<urlset>
+						<url><loc>${rootUrl}/page-a</loc></url>
+						<url><loc>${rootUrl}/page-b</loc></url>
+					</urlset>`);
+					break;
+				}
+				case '/sitemap.xml?page=2': {
+					response.setHeader('content-type', 'application/xml');
+					response.end(`<urlset>
+						<url><loc>${rootUrl}/page-b</loc></url>
+						<url><loc>${rootUrl}/page-c</loc></url>
+					</urlset>`);
+					break;
+				}
+				case '/page-a': {
+					response.end('<a href="/shared">shared</a>');
+					break;
+				}
+				case '/page-b': {
+					response.end('<a href="/broken">broken</a>');
+					break;
+				}
+				case '/page-c': {
+					response.end('<a href="/not-in-sitemap">do not recurse</a>');
+					break;
+				}
+				case '/shared': {
+					response.end('ok');
+					break;
+				}
+				case '/not-in-sitemap': {
+					response.end('<a href="/deep">deep</a>');
+					break;
+				}
+				default: {
+					response.writeHead(404).end('missing');
+				}
+			}
+		});
+		await new Promise<void>((resolve, reject) => {
+			server?.once('error', reject).listen(0, '127.0.0.1', resolve);
+		});
+		const { port } = server.address() as AddressInfo;
+		rootUrl = `http://127.0.0.1:${port}`;
+
+		const checker = new LinkChecker();
+		const pagesStarted: string[] = [];
+		checker.on('pagestart', (url) => pagesStarted.push(url.toString()));
+		const results = await checker.check({ path: rootUrl, sitemap: true });
+
+		assert.strictEqual(results.passed, false);
+		assert.deepStrictEqual(
+			pagesStarted.sort(),
+			[`${rootUrl}/page-a`, `${rootUrl}/page-b`, `${rootUrl}/page-c`].sort(),
+		);
+		assert.strictEqual(
+			results.links.filter((result) => result.url === `${rootUrl}/page-b`)
+				.length,
+			1,
+		);
+		assert.ok(
+			results.links.some(
+				(result) =>
+					result.url === `${rootUrl}/broken` &&
+					result.state === LinkState.BROKEN,
+			),
+		);
+		assert.ok(requestedPaths.includes('/not-in-sitemap'));
+		assert.ok(!requestedPaths.includes('/'));
+		assert.ok(!requestedPaths.includes('/deep'));
+	});
+
+	it('accepts an explicit sitemap URL', async () => {
+		let rootUrl = '';
+		server = http.createServer((request, response) => {
+			if (request.url === '/custom-map.xml') {
+				response.setHeader('content-type', 'application/xml');
+				response.end(
+					`<urlset><url><loc>${rootUrl}/from-map</loc></url></urlset>`,
+				);
+				return;
+			}
+			response.setHeader('content-type', 'text/html');
+			response.end('ok');
+		});
+		await new Promise<void>((resolve, reject) => {
+			server?.once('error', reject).listen(0, '127.0.0.1', resolve);
+		});
+		const { port } = server.address() as AddressInfo;
+		rootUrl = `http://127.0.0.1:${port}`;
+
+		const results = await check({
+			path: rootUrl,
+			sitemap: `${rootUrl}/custom-map.xml`,
+		});
+
+		assert.deepStrictEqual(
+			results.links.map((result) => result.url),
+			[`${rootUrl}/from-map`],
+		);
+	});
+
+	it('deduplicates explicit sitemap arrays and cyclic indexes', async () => {
+		const requestedPaths: string[] = [];
+		let rootUrl = '';
+		server = http.createServer((request, response) => {
+			requestedPaths.push(request.url || '/');
+			response.setHeader('content-type', 'application/xml');
+			if (request.url === '/index.xml') {
+				response.end(`<sitemapindex>
+					<sitemap><loc>${rootUrl}/index.xml</loc></sitemap>
+					<sitemap><loc>${rootUrl}/pages.xml</loc></sitemap>
+				</sitemapindex>`);
+				return;
+			}
+			if (request.url === '/pages.xml') {
+				response.end(`<urlset><url><loc>${rootUrl}/page</loc></url></urlset>`);
+				return;
+			}
+			response.setHeader('content-type', 'text/html');
+			response.end('ok');
+		});
+		await new Promise<void>((resolve, reject) => {
+			server?.once('error', reject).listen(0, '127.0.0.1', resolve);
+		});
+		const { port } = server.address() as AddressInfo;
+		rootUrl = `http://127.0.0.1:${port}`;
+
+		const results = await check({
+			path: rootUrl,
+			sitemap: [`${rootUrl}/index.xml`, `${rootUrl}/index.xml`],
+		});
+
+		assert.ok(results.passed);
+		assert.strictEqual(
+			requestedPaths.filter((path) => path === '/index.xml').length,
+			1,
+		);
+		assert.deepStrictEqual(
+			results.links.map((result) => result.url),
+			[`${rootUrl}/page`],
+		);
+	});
+
+	it('loads gzip-compressed sitemap indexes and children', async () => {
+		let rootUrl = '';
+		server = http.createServer((request, response) => {
+			if (request.url === '/index.xml.gz') {
+				response.setHeader('content-type', 'application/gzip');
+				response.end(
+					gzipSync(`<sitemapindex>
+						<sitemap><loc>${rootUrl}/pages.xml.gz</loc></sitemap>
+					</sitemapindex>`),
+				);
+				return;
+			}
+			if (request.url === '/pages.xml.gz') {
+				response.setHeader('content-type', 'application/gzip');
+				response.end(
+					gzipSync(
+						`<urlset><url><loc>${rootUrl}/compressed-page</loc></url></urlset>`,
+					),
+				);
+				return;
+			}
+			response.setHeader('content-type', 'text/html');
+			response.end('ok');
+		});
+		await new Promise<void>((resolve, reject) => {
+			server?.once('error', reject).listen(0, '127.0.0.1', resolve);
+		});
+		const { port } = server.address() as AddressInfo;
+		rootUrl = `http://127.0.0.1:${port}`;
+
+		const results = await check({
+			path: rootUrl,
+			sitemap: `${rootUrl}/index.xml.gz`,
+		});
+
+		assert.ok(results.passed);
+		assert.strictEqual(results.links[0].url, `${rootUrl}/compressed-page`);
+	});
+
+	it('loads child sitemaps with bounded concurrency', async () => {
+		let activeSitemapRequests = 0;
+		let maxActiveSitemapRequests = 0;
+		let rootUrl = '';
+		server = http.createServer(async (request, response) => {
+			if (request.url === '/sitemap.xml') {
+				response.setHeader('content-type', 'application/xml');
+				response.end(
+					`<sitemapindex>${Array.from(
+						{ length: 8 },
+						(_, index) =>
+							`<sitemap><loc>${rootUrl}/map-${index}.xml</loc></sitemap>`,
+					).join('')}</sitemapindex>`,
+				);
+				return;
+			}
+			const mapMatch = request.url?.match(/^\/map-(\d+)\.xml$/);
+			if (mapMatch) {
+				activeSitemapRequests++;
+				maxActiveSitemapRequests = Math.max(
+					maxActiveSitemapRequests,
+					activeSitemapRequests,
+				);
+				await new Promise((resolve) => setTimeout(resolve, 20));
+				activeSitemapRequests--;
+				response.setHeader('content-type', 'application/xml');
+				response.end(
+					`<urlset><url><loc>${rootUrl}/page-${mapMatch[1]}</loc></url></urlset>`,
+				);
+				return;
+			}
+			response.setHeader('content-type', 'text/html');
+			response.end('ok');
+		});
+		await new Promise<void>((resolve, reject) => {
+			server?.once('error', reject).listen(0, '127.0.0.1', resolve);
+		});
+		const { port } = server.address() as AddressInfo;
+		rootUrl = `http://127.0.0.1:${port}`;
+
+		const results = await check({
+			path: rootUrl,
+			sitemap: true,
+			concurrency: 3,
+		});
+
+		assert.ok(results.passed);
+		assert.strictEqual(results.links.length, 8);
+		assert.strictEqual(maxActiveSitemapRequests, 3);
+	});
+
+	it('starts page checks while sibling sitemaps are still loading', async () => {
+		let rootUrl = '';
+		let slowSitemapFinished = false;
+		let pageStartedBeforeSlowSitemapFinished = false;
+		let activeRequests = 0;
+		let maxActiveRequests = 0;
+		server = http.createServer((request, response) => {
+			activeRequests++;
+			maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
+			response.once('finish', () => activeRequests--);
+			if (request.url === '/sitemap.xml') {
+				response.setHeader('content-type', 'application/xml');
+				response.end(`<sitemapindex>
+					<sitemap><loc>${rootUrl}/fast.xml</loc></sitemap>
+					<sitemap><loc>${rootUrl}/slow.xml</loc></sitemap>
+				</sitemapindex>`);
+				return;
+			}
+			if (request.url === '/fast.xml') {
+				response.setHeader('content-type', 'application/xml');
+				response.end(`<urlset>
+					<url><loc>${rootUrl}/fast-page-a</loc></url>
+					<url><loc>${rootUrl}/fast-page-b</loc></url>
+				</urlset>`);
+				return;
+			}
+			if (request.url === '/slow.xml') {
+				setTimeout(() => {
+					slowSitemapFinished = true;
+					response.setHeader('content-type', 'application/xml');
+					response.end(
+						`<urlset><url><loc>${rootUrl}/slow-page</loc></url></urlset>`,
+					);
+				}, 500);
+				return;
+			}
+			if (request.url?.startsWith('/fast-page')) {
+				pageStartedBeforeSlowSitemapFinished = !slowSitemapFinished;
+				setTimeout(() => response.end('ok'), 50);
+				return;
+			}
+			response.end('ok');
+		});
+		await new Promise<void>((resolve, reject) => {
+			server?.once('error', reject).listen(0, '127.0.0.1', resolve);
+		});
+		const { port } = server.address() as AddressInfo;
+		rootUrl = `http://127.0.0.1:${port}`;
+
+		const results = await check({
+			path: rootUrl,
+			sitemap: true,
+			concurrency: 2,
+		});
+
+		assert.ok(results.passed);
+		assert.ok(pageStartedBeforeSlowSitemapFinished);
+		assert.ok(maxActiveRequests <= 2);
+	});
+
+	it('cancels sibling sitemap requests after the first failure', async () => {
+		let rootUrl = '';
+		let failedResponse: http.ServerResponse | undefined;
+		let resolveSlowRequestClosed: () => void;
+		const slowRequestClosed = new Promise<void>((resolve) => {
+			resolveSlowRequestClosed = resolve;
+		});
+		let slowRequestFinished = false;
+		server = http.createServer((request, response) => {
+			if (request.url === '/sitemap.xml') {
+				response.setHeader('content-type', 'application/xml');
+				response.end(`<sitemapindex>
+					<sitemap><loc>${rootUrl}/failed.xml</loc></sitemap>
+					<sitemap><loc>${rootUrl}/slow.xml</loc></sitemap>
+				</sitemapindex>`);
+				return;
+			}
+			if (request.url === '/failed.xml') {
+				failedResponse = response;
+				return;
+			}
+			if (request.url === '/slow.xml') {
+				const timer = setTimeout(() => {
+					slowRequestFinished = true;
+					response.end('<urlset/>');
+				}, 1000);
+				response.once('close', () => {
+					clearTimeout(timer);
+					resolveSlowRequestClosed();
+				});
+				failedResponse?.writeHead(500).end('failed');
+				return;
+			}
+			response.writeHead(404).end('missing');
+		});
+		await new Promise<void>((resolve, reject) => {
+			server?.once('error', reject).listen(0, '127.0.0.1', resolve);
+		});
+		const { port } = server.address() as AddressInfo;
+		rootUrl = `http://127.0.0.1:${port}`;
+
+		await expect(
+			check({ path: rootUrl, sitemap: true, concurrency: 2 }),
+		).rejects.toThrow(/HTTP 500/);
+		await Promise.race([
+			slowRequestClosed,
+			new Promise((_, reject) =>
+				setTimeout(
+					() => reject(new Error('The sibling sitemap request was not closed')),
+					250,
+				),
+			),
+		]);
+		assert.strictEqual(slowRequestFinished, false);
+	});
+
+	it('cancels page checks when later sitemap discovery fails', async () => {
+		let rootUrl = '';
+		let failedResponse: http.ServerResponse | undefined;
+		let resolvePageClosed: () => void;
+		const pageClosed = new Promise<void>((resolve) => {
+			resolvePageClosed = resolve;
+		});
+		server = http.createServer((request, response) => {
+			if (request.url === '/sitemap.xml') {
+				response.setHeader('content-type', 'application/xml');
+				response.end(`<sitemapindex>
+					<sitemap><loc>${rootUrl}/fast.xml</loc></sitemap>
+					<sitemap><loc>${rootUrl}/failed.xml</loc></sitemap>
+				</sitemapindex>`);
+				return;
+			}
+			if (request.url === '/fast.xml') {
+				response.end(`<urlset><url><loc>${rootUrl}/hang</loc></url></urlset>`);
+				return;
+			}
+			if (request.url === '/failed.xml') {
+				failedResponse = response;
+				return;
+			}
+			if (request.url === '/hang') {
+				response.once('close', resolvePageClosed);
+				failedResponse?.writeHead(500).end('failed');
+				return;
+			}
+			response.end('ok');
+		});
+		await new Promise<void>((resolve, reject) => {
+			server?.once('error', reject).listen(0, '127.0.0.1', resolve);
+		});
+		const { port } = server.address() as AddressInfo;
+		rootUrl = `http://127.0.0.1:${port}`;
+
+		await expect(
+			check({ path: rootUrl, sitemap: true, concurrency: 2 }),
+		).rejects.toThrow(/HTTP 500/);
+		await Promise.race([
+			pageClosed,
+			new Promise((_, reject) =>
+				setTimeout(
+					() => reject(new Error('The page request was not closed')),
+					250,
+				),
+			),
+		]);
+	});
+
+	it('deduplicates rewritten seeds before recursively crawling them', async () => {
+		const requestedPaths: string[] = [];
+		let rootUrl = '';
+		server = http.createServer((request, response) => {
+			requestedPaths.push(request.url || '/');
+			response.setHeader('content-type', 'text/html');
+			if (request.url === '/sitemap.xml') {
+				response.setHeader('content-type', 'application/xml');
+				response.end(`<urlset>
+					<url><loc>${rootUrl}/page-a</loc></url>
+					<url><loc>${rootUrl}/page-b</loc></url>
+				</urlset>`);
+				return;
+			}
+			if (request.url === '/page') {
+				response.end('<a href="/unlisted">unlisted</a>');
+				return;
+			}
+			if (request.url === '/unlisted') {
+				response.end('<a href="/deep">deep</a>');
+				return;
+			}
+			response.end('ok');
+		});
+		await new Promise<void>((resolve, reject) => {
+			server?.once('error', reject).listen(0, '127.0.0.1', resolve);
+		});
+		const { port } = server.address() as AddressInfo;
+		rootUrl = `http://127.0.0.1:${port}`;
+
+		const results = await check({
+			path: rootUrl,
+			sitemap: true,
+			recurse: true,
+			urlRewriteExpressions: [{ pattern: /-[ab]$/, replacement: '' }],
+		});
+
+		assert.ok(results.passed);
+		assert.strictEqual(
+			requestedPaths.filter((requestPath) => requestPath === '/page').length,
+			1,
+		);
+		assert.ok(requestedPaths.includes('/unlisted'));
+		assert.ok(requestedPaths.includes('/deep'));
+	});
+
+	it('honors retry policies for sitemap requests', async () => {
+		let rootUrl = '';
+		let rateLimitAttempts = 0;
+		let serverErrorAttempts = 0;
+		let networkErrorAttempts = 0;
+		let streamErrorAttempts = 0;
+		let invalidXmlAttempts = 0;
+		server = http.createServer((request, response) => {
+			if (request.url === '/rate-limited.xml' && rateLimitAttempts++ === 0) {
+				response.writeHead(429, { 'Retry-After': '0' }).end('retry');
+				return;
+			}
+			if (request.url === '/server-error.xml' && serverErrorAttempts++ === 0) {
+				response.writeHead(500).end('retry');
+				return;
+			}
+			if (
+				request.url === '/network-error.xml' &&
+				networkErrorAttempts++ === 0
+			) {
+				request.socket.destroy();
+				return;
+			}
+			if (request.url === '/stream-error.xml' && streamErrorAttempts++ === 0) {
+				response.writeHead(200, { 'Content-Type': 'application/xml' });
+				response.write('<urlset>');
+				response.socket?.destroy();
+				return;
+			}
+			if (request.url === '/invalid.xml') {
+				invalidXmlAttempts++;
+				response.end('<urlset><url></urlset>');
+				return;
+			}
+			if (
+				request.url === '/rate-limited.xml' ||
+				request.url === '/server-error.xml' ||
+				request.url === '/network-error.xml' ||
+				request.url === '/stream-error.xml'
+			) {
+				response.setHeader('content-type', 'application/xml');
+				response.end(`<urlset><url><loc>${rootUrl}/page</loc></url></urlset>`);
+				return;
+			}
+			response.end('ok');
+		});
+		await new Promise<void>((resolve, reject) => {
+			server?.once('error', reject).listen(0, '127.0.0.1', resolve);
+		});
+		const { port } = server.address() as AddressInfo;
+		rootUrl = `http://127.0.0.1:${port}`;
+
+		const retryAfterChecker = new LinkChecker();
+		const retryAfterEvents: Array<{ status: number }> = [];
+		retryAfterChecker.on('retry', (event) => retryAfterEvents.push(event));
+		const rateLimitResult = await retryAfterChecker.check({
+			path: rootUrl,
+			sitemap: `${rootUrl}/rate-limited.xml`,
+			retry: true,
+		});
+		assert.ok(rateLimitResult.passed);
+		assert.strictEqual(rateLimitAttempts, 2);
+		expect(retryAfterEvents).toEqual([
+			expect.objectContaining({ status: 429 }),
+		]);
+
+		const errorChecker = new LinkChecker();
+		const errorRetryEvents: Array<{ status: number }> = [];
+		errorChecker.on('retry', (event) => errorRetryEvents.push(event));
+		const serverErrorResult = await errorChecker.check({
+			path: rootUrl,
+			sitemap: `${rootUrl}/server-error.xml`,
+			retryErrors: true,
+			retryErrorsCount: 1,
+			retryErrorsJitter: 0,
+		});
+		assert.ok(serverErrorResult.passed);
+		assert.strictEqual(serverErrorAttempts, 2);
+		expect(errorRetryEvents).toEqual([
+			expect.objectContaining({ status: 500 }),
+		]);
+
+		const networkChecker = new LinkChecker();
+		const networkRetryEvents: Array<{ status: number }> = [];
+		networkChecker.on('retry', (event) => networkRetryEvents.push(event));
+		const networkErrorResult = await networkChecker.check({
+			path: rootUrl,
+			sitemap: `${rootUrl}/network-error.xml`,
+			retryErrors: true,
+			retryErrorsCount: 1,
+			retryErrorsJitter: 0,
+		});
+		assert.ok(networkErrorResult.passed);
+		assert.strictEqual(networkErrorAttempts, 2);
+		expect(networkRetryEvents).toEqual([
+			expect.objectContaining({ status: 0 }),
+		]);
+
+		const streamChecker = new LinkChecker();
+		const streamRetryEvents: Array<{ status: number }> = [];
+		streamChecker.on('retry', (event) => streamRetryEvents.push(event));
+		const streamErrorResult = await streamChecker.check({
+			path: rootUrl,
+			sitemap: `${rootUrl}/stream-error.xml`,
+			retryErrors: true,
+			retryErrorsCount: 1,
+			retryErrorsJitter: 0,
+		});
+		assert.ok(streamErrorResult.passed);
+		assert.strictEqual(streamErrorAttempts, 2);
+		expect(streamRetryEvents).toEqual([expect.objectContaining({ status: 0 })]);
+
+		await expect(
+			check({
+				path: rootUrl,
+				sitemap: `${rootUrl}/invalid.xml`,
+				retryErrors: true,
+				retryErrorsCount: 1,
+				retryErrorsJitter: 0,
+			}),
+		).rejects.toThrow(/Unable to parse sitemap/);
+		assert.strictEqual(invalidXmlAttempts, 1);
+	});
+
+	it('releases the global request slot during sitemap retry backoff', async () => {
+		let rootUrl = '';
+		let rateLimitAttempts = 0;
+		let pageStartedDuringBackoff = false;
+		server = http.createServer((request, response) => {
+			if (request.url === '/fast.xml') {
+				response.end(
+					`<urlset><url><loc>${rootUrl}/fast-page</loc></url></urlset>`,
+				);
+				return;
+			}
+			if (request.url === '/rate-limited.xml') {
+				rateLimitAttempts++;
+				if (rateLimitAttempts === 1) {
+					response.writeHead(429, { 'Retry-After': '0.2' }).end('retry');
+					return;
+				}
+				response.end(
+					`<urlset><url><loc>${rootUrl}/rate-page</loc></url></urlset>`,
+				);
+				return;
+			}
+			if (request.url === '/fast-page') {
+				pageStartedDuringBackoff = rateLimitAttempts === 1;
+			}
+			response.end('ok');
+		});
+		await new Promise<void>((resolve, reject) => {
+			server?.once('error', reject).listen(0, '127.0.0.1', resolve);
+		});
+		const { port } = server.address() as AddressInfo;
+		rootUrl = `http://127.0.0.1:${port}`;
+
+		const results = await check({
+			path: rootUrl,
+			sitemap: [`${rootUrl}/fast.xml`, `${rootUrl}/rate-limited.xml`],
+			concurrency: 1,
+			retry: true,
+		});
+
+		assert.ok(results.passed);
+		assert.strictEqual(rateLimitAttempts, 2);
+		assert.ok(pageStartedDuringBackoff);
+	});
+
+	it('does not reacquire a request slot after an aborted sitemap retry', async () => {
+		let rootUrl = '';
+		let fastResponse: http.ServerResponse | undefined;
+		let invalidResponse: http.ServerResponse | undefined;
+		let retryStarted = false;
+		let hangingPageStarted = false;
+
+		const finishFastResponse = () => {
+			if (!retryStarted || !fastResponse) return;
+			fastResponse.end(`<urlset>
+				<url><loc>${rootUrl}/hanging-1</loc></url>
+				<url><loc>${rootUrl}/hanging-2</loc></url>
+			</urlset>`);
+			fastResponse = undefined;
+		};
+		const finishInvalidResponse = () => {
+			if (!hangingPageStarted || !invalidResponse) return;
+			invalidResponse.end(
+				'<urlset><url><loc>mailto:test@example.com</loc></url></urlset>',
+			);
+			invalidResponse = undefined;
+		};
+
+		server = http.createServer((request, response) => {
+			switch (request.url) {
+				case '/fast.xml': {
+					fastResponse = response;
+					finishFastResponse();
+					break;
+				}
+				case '/retry.xml': {
+					retryStarted = true;
+					response.writeHead(429, { 'Retry-After': '60' }).end('retry');
+					finishFastResponse();
+					break;
+				}
+				case '/invalid.xml': {
+					invalidResponse = response;
+					finishInvalidResponse();
+					break;
+				}
+				case '/hanging-1':
+				case '/hanging-2': {
+					hangingPageStarted = true;
+					finishInvalidResponse();
+					break;
+				}
+				default: {
+					response.end('ok');
+				}
+			}
+		});
+		await new Promise<void>((resolve, reject) => {
+			server?.once('error', reject).listen(0, '127.0.0.1', resolve);
+		});
+		const { port } = server.address() as AddressInfo;
+		rootUrl = `http://127.0.0.1:${port}`;
+		const checker = new LinkChecker();
+		let retryEvents = 0;
+		checker.on('retry', () => retryEvents++);
+
+		let timeout: NodeJS.Timeout | undefined;
+		try {
+			await expect(
+				Promise.race([
+					checker.check({
+						path: rootUrl,
+						sitemap: [
+							`${rootUrl}/fast.xml`,
+							`${rootUrl}/retry.xml`,
+							`${rootUrl}/invalid.xml`,
+						],
+						concurrency: 2,
+						retry: true,
+					}),
+					new Promise<never>((_, reject) => {
+						timeout = setTimeout(
+							() => reject(new Error('sitemap cancellation timed out')),
+							1000,
+						);
+					}),
+				]),
+			).rejects.toThrow(/Invalid URL protocol in sitemap/);
+		} finally {
+			if (timeout) clearTimeout(timeout);
+		}
+		assert.strictEqual(retryEvents, 1);
+		assert.ok(hangingPageStarted);
+	});
+
+	it('applies headers and URL rewrites to sitemap redirects and pages', async () => {
+		const requestedPaths: string[] = [];
+		let rootUrl = '';
+		server = http.createServer((request, response) => {
+			assert.strictEqual(request.headers['x-sitemap-test'], 'present');
+			requestedPaths.push(request.url || '/');
+			if (request.url === '/sitemap.xml') {
+				response.writeHead(302, {
+					Location: 'https://production.example/actual.xml',
+				});
+				response.end();
+				return;
+			}
+			if (request.url === '/actual.xml') {
+				response.setHeader('content-type', 'application/xml');
+				response.end(`<urlset>
+					<url><loc>https://production.example/page</loc></url>
+				</urlset>`);
+				return;
+			}
+			response.setHeader('content-type', 'text/html');
+			response.end('ok');
+		});
+		await new Promise<void>((resolve, reject) => {
+			server?.once('error', reject).listen(0, '127.0.0.1', resolve);
+		});
+		const { port } = server.address() as AddressInfo;
+		rootUrl = `http://127.0.0.1:${port}`;
+
+		const results = await check({
+			path: 'https://production.example',
+			sitemap: true,
+			headers: { 'X-Sitemap-Test': 'present' },
+			urlRewriteExpressions: [
+				{
+					pattern: /^https:\/\/production\.example/,
+					replacement: rootUrl,
+				},
+			],
+		});
+
+		assert.ok(results.passed);
+		assert.deepStrictEqual(requestedPaths, [
+			'/sitemap.xml',
+			'/actual.xml',
+			'/page',
+		]);
+		assert.strictEqual(results.links[0].url, `${rootUrl}/page`);
+	});
+
+	it('rejects redirects to skipped sitemap URLs', async () => {
+		let rootUrl = '';
+		server = http.createServer((request, response) => {
+			if (request.url === '/sitemap.xml') {
+				response.writeHead(302, { Location: `${rootUrl}/blocked.xml` });
+				response.end();
+				return;
+			}
+			response.end('<urlset/>');
+		});
+		await new Promise<void>((resolve, reject) => {
+			server?.once('error', reject).listen(0, '127.0.0.1', resolve);
+		});
+		const { port } = server.address() as AddressInfo;
+		rootUrl = `http://127.0.0.1:${port}`;
+
+		await expect(
+			check({ path: rootUrl, sitemap: true, linksToSkip: ['blocked'] }),
+		).rejects.toThrow(/excluded by a skip rule/);
+	});
+
+	it('honors redirect warning and error policies for sitemap requests', async () => {
+		const requestedPaths: string[] = [];
+		let rootUrl = '';
+		server = http.createServer((request, response) => {
+			requestedPaths.push(request.url || '/');
+			if (request.url === '/sitemap.xml') {
+				response.writeHead(302, { Location: `${rootUrl}/actual.xml` });
+				response.end();
+				return;
+			}
+			if (request.url === '/actual.xml') {
+				response.setHeader('content-type', 'application/xml');
+				response.end(`<urlset><url><loc>${rootUrl}/page</loc></url></urlset>`);
+				return;
+			}
+			response.setHeader('content-type', 'text/html');
+			response.end('ok');
+		});
+		await new Promise<void>((resolve, reject) => {
+			server?.once('error', reject).listen(0, '127.0.0.1', resolve);
+		});
+		const { port } = server.address() as AddressInfo;
+		rootUrl = `http://127.0.0.1:${port}`;
+
+		const checker = new LinkChecker();
+		const redirects: Array<{ url: string; targetUrl?: string }> = [];
+		checker.on('redirect', (redirect) => redirects.push(redirect));
+		const results = await checker.check({
+			path: rootUrl,
+			sitemap: true,
+			redirects: 'warn',
+		});
+
+		assert.ok(results.passed);
+		expect(redirects).toEqual([
+			expect.objectContaining({
+				url: `${rootUrl}/sitemap.xml`,
+				targetUrl: `${rootUrl}/actual.xml`,
+			}),
+		]);
+		const actualRequests = requestedPaths.filter(
+			(path) => path === '/actual.xml',
+		).length;
+		await expect(
+			check({ path: rootUrl, sitemap: true, redirects: 'error' }),
+		).rejects.toThrow(/HTTP 302/);
+		assert.strictEqual(
+			requestedPaths.filter((path) => path === '/actual.xml').length,
+			actualRequests,
+		);
+	});
+
+	it('combines sitemap seeds with opt-in recursive crawling', async () => {
+		const requestedPaths: string[] = [];
+		let rootUrl = '';
+		server = http.createServer((request, response) => {
+			requestedPaths.push(request.url || '/');
+			response.setHeader('content-type', 'text/html');
+			if (request.url === '/sitemap.xml') {
+				response.setHeader('content-type', 'application/xml');
+				response.end(`<urlset><url><loc>${rootUrl}/page</loc></url></urlset>`);
+				return;
+			}
+			if (request.url === '/page') {
+				response.end('<a href="/unlisted">unlisted</a>');
+				return;
+			}
+			if (request.url === '/unlisted') {
+				response.end('<a href="/deep">deep</a>');
+				return;
+			}
+			response.end('ok');
+		});
+		await new Promise<void>((resolve, reject) => {
+			server?.once('error', reject).listen(0, '127.0.0.1', resolve);
+		});
+		const { port } = server.address() as AddressInfo;
+		rootUrl = `http://127.0.0.1:${port}`;
+
+		const results = await check({
+			path: rootUrl,
+			sitemap: true,
+			recurse: true,
+		});
+
+		assert.ok(results.passed);
+		assert.ok(requestedPaths.includes('/unlisted'));
+		assert.ok(requestedPaths.includes('/deep'));
+	});
+
+	it('reports invalid and unusable sitemaps clearly', async () => {
+		let rootUrl = '';
+		server = http.createServer((request, response) => {
+			response.setHeader('content-type', 'application/xml');
+			switch (request.url) {
+				case '/missing.xml': {
+					response.writeHead(404).end('missing');
+					break;
+				}
+				case '/empty-response.xml': {
+					response.writeHead(204).end();
+					break;
+				}
+				case '/not-a-sitemap.xml': {
+					response.end('<feed/>');
+					break;
+				}
+				case '/invalid-location.xml': {
+					response.end('<urlset><url><loc>http://[</loc></url></urlset>');
+					break;
+				}
+				case '/invalid-protocol.xml': {
+					response.end(
+						'<urlset><url><loc>mailto:test@example.com</loc></url></urlset>',
+					);
+					break;
+				}
+				default: {
+					response.end('<urlset/>');
+				}
+			}
+		});
+		await new Promise<void>((resolve, reject) => {
+			server?.once('error', reject).listen(0, '127.0.0.1', resolve);
+		});
+		const { port } = server.address() as AddressInfo;
+		rootUrl = `http://127.0.0.1:${port}`;
+
+		await expect(
+			check({ path: rootUrl, sitemap: 'not a URL' }),
+		).rejects.toThrow(/Invalid sitemap URL/);
+		await expect(
+			check({ path: rootUrl, sitemap: 'ftp://example.com/sitemap.xml' }),
+		).rejects.toThrow(/Invalid sitemap URL protocol/);
+		await expect(
+			check({ path: rootUrl, sitemap: `${rootUrl}/missing.xml` }),
+		).rejects.toThrow(/HTTP 404/);
+		await expect(
+			check({ path: rootUrl, sitemap: `${rootUrl}/empty-response.xml` }),
+		).rejects.toThrow(/empty response/);
+		await expect(
+			check({ path: rootUrl, sitemap: `${rootUrl}/not-a-sitemap.xml` }),
+		).rejects.toThrow(/Unable to parse sitemap/);
+		await expect(
+			check({ path: rootUrl, sitemap: `${rootUrl}/invalid-location.xml` }),
+		).rejects.toThrow(/Invalid URL in sitemap/);
+		await expect(
+			check({ path: rootUrl, sitemap: `${rootUrl}/invalid-protocol.xml` }),
+		).rejects.toThrow(/Invalid URL protocol in sitemap/);
+		await expect(
+			check({ path: rootUrl, sitemap: `${rootUrl}/empty.xml` }),
+		).rejects.toThrow(/did not contain any page URLs/);
+	});
+
+	it('rejects sitemap mode for local filesystem paths', async () => {
+		await expect(
+			check({ path: 'test/fixtures/basic', sitemap: true }),
+		).rejects.toThrow(/can only be used with HTTP paths/);
+	});
+});

--- a/test/test.sitemap.ts
+++ b/test/test.sitemap.ts
@@ -410,32 +410,53 @@ describe('sitemap crawling', () => {
 		let activeSitemapRequests = 0;
 		let maxActiveSitemapRequests = 0;
 		let rootUrl = '';
+		const childSitemapPaths = Array.from(
+			{ length: 8 },
+			(_, index) => `/map-${index}.xml`,
+		);
+		const sendChildSitemap = async (
+			response: http.ServerResponse,
+			pageIndex: number,
+		) => {
+			activeSitemapRequests++;
+			maxActiveSitemapRequests = Math.max(
+				maxActiveSitemapRequests,
+				activeSitemapRequests,
+			);
+			await new Promise((resolve) => setTimeout(resolve, 20));
+			activeSitemapRequests--;
+			response.setHeader('content-type', 'application/xml');
+			response.end(
+				`<urlset><url><loc>${rootUrl}/page-${pageIndex}</loc></url></urlset>`,
+			);
+		};
 		server = http.createServer(async (request, response) => {
 			if (request.url === '/sitemap.xml') {
 				response.setHeader('content-type', 'application/xml');
 				response.end(
-					`<sitemapindex>${Array.from(
-						{ length: 8 },
-						(_, index) =>
-							`<sitemap><loc>${rootUrl}/map-${index}.xml</loc></sitemap>`,
-					).join('')}</sitemapindex>`,
+					`<sitemapindex>${childSitemapPaths
+						.map((path) => `<sitemap><loc>${rootUrl}${path}</loc></sitemap>`)
+						.join('')}</sitemapindex>`,
 				);
 				return;
 			}
-			const mapMatch = request.url?.match(/^\/map-(\d+)\.xml$/);
-			if (mapMatch) {
-				activeSitemapRequests++;
-				maxActiveSitemapRequests = Math.max(
-					maxActiveSitemapRequests,
-					activeSitemapRequests,
-				);
-				await new Promise((resolve) => setTimeout(resolve, 20));
-				activeSitemapRequests--;
-				response.setHeader('content-type', 'application/xml');
-				response.end(
-					`<urlset><url><loc>${rootUrl}/page-${mapMatch[1]}</loc></url></urlset>`,
-				);
-				return;
+			switch (request.url) {
+				case '/map-0.xml':
+					return sendChildSitemap(response, 0);
+				case '/map-1.xml':
+					return sendChildSitemap(response, 1);
+				case '/map-2.xml':
+					return sendChildSitemap(response, 2);
+				case '/map-3.xml':
+					return sendChildSitemap(response, 3);
+				case '/map-4.xml':
+					return sendChildSitemap(response, 4);
+				case '/map-5.xml':
+					return sendChildSitemap(response, 5);
+				case '/map-6.xml':
+					return sendChildSitemap(response, 6);
+				case '/map-7.xml':
+					return sendChildSitemap(response, 7);
 			}
 			response.setHeader('content-type', 'text/html');
 			response.end('ok');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,10 @@
 		"outDir": "build",
 		"module": "NodeNext",
 		"moduleResolution": "NodeNext",
+		"allowJs": true,
+		"skipLibCheck": true,
 		"allowSyntheticDefaultImports": true,
 		"resolveJsonModule": true
 	},
-	"include": ["src/*.ts", "test/*.ts"]
+	"include": ["src/*.ts", "src/*.cjs", "test/*.ts"]
 }


### PR DESCRIPTION
Fixes #346

## Summary

- add sitemap crawling through the API/config plus --sitemap and repeatable --sitemap-url CLI flags
- stream strict XML and gzip parsing for URL sets, nested sitemap indexes, explicit sitemap lists, and query-based pagination
- apply the existing headers, redirects, rewrites, retries, skip rules, timeout, TLS, and recurse behavior to sitemap discovery
- share the configured global concurrency limit across sitemap and page requests, with abort-safe retry pausing and failure cleanup
- document the new modes and package the parser for both npm and standalone Bun binaries

## Validation

- npm test -- --run: 335 tests passed across 20 files
- npm run coverage: 94.48% statements, 88.99% branches, 97.29% functions, 94.50% lines; sitemap parser has 100% statements/functions/lines
- npm run build and npm run lint
- npm run docs-test: 17 links passed
- npm run build-binaries: Linux, Windows, and macOS targets built
- compiled macOS binary crawled a nested gzip sitemap end to end
- npm pack --dry-run verified all runtime artifacts
- npm audit --omit=dev found 0 vulnerabilities
- two independent review agents signed off with no actionable findings
